### PR TITLE
Allow periods in Custom App Name

### DIFF
--- a/deployments/hostpools/uiFormDefinition.json
+++ b/deployments/hostpools/uiFormDefinition.json
@@ -2312,8 +2312,8 @@
 														"required": true,
 														"validations": [
 															{
-																"regex": "^(?![_-])[A-Za-z0-9_-]{1,13}(?<![_-])$",
-																"message": "The value must not contain spaces or end or begin with a dash or underscore."
+																"regex": "^(?![_.-])[A-Za-z0-9_.-]{1,13}(?<![_.-])$",
+																"message": "Name of the script/application without its file extension. Use 1-13 characters (letters, numbers, hyphens, underscores, periods). Must start and end with a letter or number."
 															}
 														]
 													}


### PR DESCRIPTION
For a Blue Button Host Pool Deployment, when using a Custom Script/App to run during the deployment, the regex doesn't accept periods, so something like putty-0.83 would fail. I saw that there is a character limit of 13 that I was going to change, but I'm wondering if maybe that limit is there because you use the value to create a local folder to copy and run from and you wanted to stay under a 15 character limit. If there is no reason to have a limit, then I would like it bigger so that I can build my automation to use the file name from the artifacts container minus the extension.  