### PR TITLE
refactor: replace Compress-Archive with ZipFile for long-path support

### DIFF
--- a/.common/powerShellFunctions/Storage/Compress-SubFolderContents.ps1
+++ b/.common/powerShellFunctions/Storage/Compress-SubFolderContents.ps1
@@ -15,7 +15,7 @@ Specifies the location for the .zip files.
 Specifies how much compression to apply when creating the archive file. Fastest as default.
 
 .PARAMETER Confirm
-Will promt user to confirm the action to create invasible commands
+Will prompt user to confirm the action to create invisible commands
 
 .PARAMETER WhatIf
 Dry run of the script
@@ -24,9 +24,50 @@ Dry run of the script
     Compress-SubFolderContents -SourceFolderPath "\\path\to\sourcefolder" -DestinationFolderPath "\\path\to\destinationfolder"
 
     Creates the "\\path\to\destinationfolder" if not existing
-    Moves there the scriptExtensionMasterInstaller.ps1 master script for CSE
     For each subfolder in "\\path\to\sourcefolder" creates an archive with the fastest compression level named "subfolder.zip" in the "\\path\to\destinationfolder".
 #>
+
+function ConvertTo-LongSafePath {
+    param([string] $Path)
+    $trimmed = $Path.TrimEnd('\')
+
+    # Already prefixed — return as-is to prevent double-prefixing
+    if ($trimmed.StartsWith('\\?\')) {
+        return $trimmed
+    }
+
+    if (-not [System.IO.Path]::IsPathRooted($trimmed)) {
+        throw "ConvertTo-LongSafePath requires an absolute path. Received: '$trimmed'"
+    }
+
+    if ($trimmed.StartsWith('\\')) {
+        # UNC path: \\server\share → \\?\UNC\server\share
+        $uncBody = $trimmed.Substring(2)
+        return "\\?\UNC\" + $uncBody
+    } else {
+        # Local path: C:\foo → \\?\C:\foo
+        return "\\?\" + $trimmed
+    }
+}
+
+function Remove-LongSafePrefix {
+    <#
+    .SYNOPSIS
+    Strips any \\?\ or \\?\UNC\ prefix from a path so it can be used for
+    relative-path substring math. Both the base path and child paths must be
+    normalised through this function before Substring() calls are made,
+    guaranteeing a consistent format regardless of how Get-ChildItem resolves
+    long-safe roots on different PS versions / OS configurations.
+    #>
+    param([string] $Path)
+    if ($Path.StartsWith('\\?\UNC\')) {
+        return '\\' + $Path.Substring(8)   # \\?\UNC\server\share → \\server\share
+    }
+    if ($Path.StartsWith('\\?\')) {
+        return $Path.Substring(4)           # \\?\C:\foo → C:\foo
+    }
+    return $Path
+}
 
 function Compress-SubFolderContents {
 
@@ -48,43 +89,163 @@ function Compress-SubFolderContents {
             Mandatory = $false,
             HelpMessage = "Specifies how much compression to apply when creating the archive file. Fastest as default."
         )]
+        [ValidateSet("Optimal", "Fastest", "NoCompression")]
         [string] $CompressionLevel = "Fastest"
     )
 
-    
-    Write-Verbose "## Checking destination folder existance $DestinationFolderPath"
-    If (!(Test-path $DestinationFolderPath)) {
-        Write-Verbose "Not existing, creating..."
-        New-Item -ItemType "directory" -Path $DestinationFolderPath
-    }
+    try {
 
-    Write-Verbose "## Create archives "
-    $subfolders = Get-ChildItem $SourceFolderPath | Where-Object {$_.PSISContainer}
-    foreach ($sf in $subfolders){
-        try {
-            $sfname = $sf.Name + ".zip"
-            $destinationFilePath = Join-Path -Path $DestinationFolderPath -ChildPath ($sfname)
-            $sourceFilePath = Join-Path -Path $sf.FullName -ChildPath "*"
+        # Always call Add-Type unconditionally — it is idempotent and safe to
+        # call even when the assembly is already loaded. The previous guard
+        # (-not ([System.IO.Compression.ZipFile] -as [type])) was unreliable:
+        # referencing the type literal throws if the assembly is not loaded,
+        # so the condition itself would error before the Add-Type could run.
+        Add-Type -AssemblyName System.IO.Compression.FileSystem
 
-            Write-Verbose "Working on subfolder $sf"
-            Write-Verbose "Archive will be created from path $sourceFilePath"
-            Write-Verbose "Archive will be stored as $destinationFilePath"
-            
-            $CompressInputObject = @{
-                Path = $sourceFilePath
-                DestinationPath = $destinationFilePath
-                CompressionLevel = $CompressionLevel   
-                Force = $true 
-            }
-
-            Write-Verbose "Starting compression...."
-            if ($PSCmdlet.ShouldProcess("Required files from $sourceFilePath to $destinationFilePath", "Compress")) {
-                Compress-Archive @CompressInputObject
-            }
-            Write-Verbose "Compression completed."
+        # Map compression level string to enum once, outside the loop.
+        # ValidateSet guarantees only valid values reach this switch.
+        $compressionLevelEnum = switch ($CompressionLevel) {
+            "Optimal"       { [System.IO.Compression.CompressionLevel]::Optimal }
+            "Fastest"       { [System.IO.Compression.CompressionLevel]::Fastest }
+            "NoCompression" { [System.IO.Compression.CompressionLevel]::NoCompression }
         }
-        catch {
-            Write-Error "Compression FAILED: $_"
-        } 
+
+        if (!(Test-Path -Path $SourceFolderPath)) {
+            throw "Source folder not found: '$SourceFolderPath'"
+        }
+
+        Write-Verbose "## Checking destination folder existence: $DestinationFolderPath"
+        if (!(Test-Path -Path $DestinationFolderPath)) {
+            Write-Verbose "Not existing, creating..."
+            New-Item -ItemType Directory -Path $DestinationFolderPath | Out-Null
+        }
+
+        Write-Verbose "## Creating archives"
+        $subfolders = Get-ChildItem -Path $SourceFolderPath -Directory
+
+        foreach ($sf in $subfolders) {
+            try {
+                $destinationFilePath = Join-Path -Path $DestinationFolderPath -ChildPath ($sf.Name + ".zip")
+                $tempFilePath        = $destinationFilePath + ".tmp"
+                $safeTempFilePath    = ConvertTo-LongSafePath $tempFilePath
+
+                Write-Verbose "Working on subfolder: $($sf.Name)"
+                Write-Verbose "Archive will be created from: $($sf.FullName)"
+                Write-Verbose "Archive will be stored as: $destinationFilePath"
+
+                # Normalise the base path by stripping any \\?\ prefix that
+                # Get-ChildItem may have added. Both the base and each child's
+                # FullName are stripped through Remove-LongSafePrefix before
+                # Substring() is called, ensuring consistent path math regardless
+                # of how PowerShell resolves long-safe roots on this system/version.
+                $baseFullName = (Remove-LongSafePrefix $sf.FullName).TrimEnd('\')
+                $baseLen      = $baseFullName.Length + 1
+
+                Write-Verbose "Starting compression..."
+
+                # $zipArchive is initialised to $null so the finally block can
+                # safely call Dispose() even if ZipFile::Open() throws before
+                # the variable is assigned.
+                $zipArchive  = $null
+                $failedFiles = [System.Collections.Generic.List[string]]::new()
+
+                if ($PSCmdlet.ShouldProcess($destinationFilePath, "Create archive from $($sf.FullName)")) {
+
+                    # Write to a .tmp file first. The old zip (if any) is only
+                    # replaced after all entries are written successfully and the
+                    # archive is disposed, so a failed compression never leaves
+                    # the destination in a partial or missing state.
+                    if (Test-Path -Path $tempFilePath) {
+                        Remove-Item -Path $tempFilePath -Force
+                    }
+
+                    $zipArchive = [System.IO.Compression.ZipFile]::Open(
+                        $safeTempFilePath,
+                        [System.IO.Compression.ZipArchiveMode]::Create
+                    )
+
+                    try {
+                        # Detect truly-empty subdirectories (no files anywhere in subtree)
+                        # and add placeholder entries so the directory is preserved in the zip.
+                        # EnumerateFiles+MoveNext short-circuits on the first file found,
+                        # avoiding a full recursive scan for non-empty directories.
+                        # ConvertTo-LongSafePath is applied here because EnumerateFiles is a
+                        # .NET I/O call and must receive a long-safe path for deep trees.
+                        Get-ChildItem -Path $sf.FullName -Directory -Recurse -Force |
+                        Where-Object {
+                            -not [System.IO.Directory]::EnumerateFiles(
+                                (ConvertTo-LongSafePath $_.FullName), '*', 'AllDirectories'
+                            ).GetEnumerator().MoveNext()
+                        } |
+                        ForEach-Object {
+                            # Strip any long-safe prefix before substring math, then
+                            # normalise to forward slashes — ZIP spec requires '/' separators.
+                            $normalFull  = (Remove-LongSafePrefix $_.FullName).TrimEnd('\')
+                            $relativeDir = ($normalFull.Substring($baseLen) -replace '\\', '/') + '/'
+                            $zipArchive.CreateEntry($relativeDir) | Out-Null
+                        }
+
+                        # Add all files. Long-safe path is used for the .NET I/O call;
+                        # the plain normalised path is used for the in-zip entry name.
+                        Get-ChildItem -Path $sf.FullName -File -Recurse -Force | ForEach-Object {
+                            try {
+                                $longSafePath = ConvertTo-LongSafePath $_.FullName
+                                $normalFull   = (Remove-LongSafePrefix $_.FullName).TrimEnd('\')
+                                $relativePath = $normalFull.Substring($baseLen) -replace '\\', '/'
+
+                                [System.IO.Compression.ZipFileExtensions]::CreateEntryFromFile(
+                                    $zipArchive,
+                                    $longSafePath,
+                                    $relativePath,
+                                    $compressionLevelEnum
+                                ) | Out-Null
+                            }
+                            catch {
+                                # Collect failures rather than silently swallowing them.
+                                # Write-Error (not Write-Warning) ensures automation pipelines
+                                # can detect that the archive is incomplete.
+                                $failedFiles.Add($_.FullName)
+                                Write-Error "Failed to add file '$($_.FullName)': $_"
+                            }
+                        }
+                    }
+                    finally {
+                        # Ensures the zip stream is flushed and closed even if an
+                        # error occurs mid-archive. Safe to call when $zipArchive is
+                        # $null (i.e. if Open() itself threw).
+                        if ($null -ne $zipArchive) {
+                            $zipArchive.Dispose()
+                            $zipArchive = $null
+                        }
+                    }
+
+                    # Only promote the temp file to the final destination if all
+                    # files were written successfully. A partial archive is removed
+                    # and an error is raised so automation is not misled.
+                    if ($failedFiles.Count -gt 0) {
+                        Remove-Item -Path $tempFilePath -Force -ErrorAction SilentlyContinue
+                        throw "Archive for '$($sf.Name)' is incomplete — $($failedFiles.Count) file(s) could not be added."
+                    }
+
+                    # Atomically replace the old zip only after a clean write.
+                    if (Test-Path -Path $destinationFilePath) {
+                        Remove-Item -Path $destinationFilePath -Force
+                    }
+                    Move-Item -Path $tempFilePath -Destination $destinationFilePath
+
+                    Write-Verbose "Compression completed: $destinationFilePath"
+                }
+            }
+            catch {
+                # Clean up orphaned temp file if something went wrong after it was created.
+                if (Test-Path -LiteralPath $tempFilePath) {
+                    Remove-Item -Path $tempFilePath -Force -ErrorAction SilentlyContinue
+                }
+                Write-Error "Compression FAILED for '$($sf.Name)': $_"
+            }
+        }
+    }
+    catch {
+        Write-Error "Fatal error in Compress-SubFolderContents: $_"
     }
 }


### PR DESCRIPTION
Fixed Compress-SubFolderContents.ps1 that is failing when the archive folder is greater than 10 GB.

Compress-Archive fails on deep folder structures due to the 260-character MAX_PATH limit. Replaced with System.IO.Compression.ZipFile which accepts \\?\ prefixed paths, lifting that restriction.

Key changes:
- Add ConvertTo-LongSafePath helper to apply \\?\ and \\?\UNC\ prefixes for all .NET I/O calls
- Add Remove-LongSafePrefix helper to normalize paths before relative-path Substring() math, ensuring consistent results regardless of how Get-ChildItem resolves FullName across PS versions
- Preserve empty subdirectories in archives via ZipArchive.CreateEntry()
- Write archives to a .tmp file first; promote to final destination only after all entries are written and the archive is disposed, preventing partial or missing archives on failure
- Collect per-file write failures and throw after the loop so automation pipelines are not misled by a silently incomplete archive
- Add ValidateSet on CompressionLevel and map to enum once outside the loop
- Replace PSISContainer filter with Get-ChildItem -Directory
- Add source folder existence check with throw for consistent error handling