### PR TITLE
Make ADMX template downloads non-fatal in Edge and Office 365 policy scripts

### DIFF
--- a/customer-examples/artifacts/Configure-EdgePolicy/Configure-EdgePolicy.ps1
+++ b/customer-examples/artifacts/Configure-EdgePolicy/Configure-EdgePolicy.ps1
@@ -645,23 +645,27 @@ If ($null -ne $EdgeTemplatesCab) {
     Write-Log -Category Info -Message "Bundled Edge policy CAB found: '$EdgeTemplatesCab'."
 } ElseIf (-not (Test-Path $Script:EdgeAdmx)) {
     Write-Log -Category Info -Message "'msedge.admx' not found in PolicyDefinitions and no bundled CAB present. Attempting to download Edge policy templates."
-    $APIUrl = "https://edgeupdates.microsoft.com/api/products?view=enterprise"
-    $EdgeUpdatesJSON = Invoke-WebRequest -Uri $APIUrl -UseBasicParsing
-    $content = $EdgeUpdatesJSON.content | ConvertFrom-Json      
-    $Edgereleases = ($content | Where-Object { $_.Product -eq 'Stable' }).releases
-    $latestrelease = $Edgereleases | Where-Object { $_.Platform -eq 'Windows' -and $_.Architecture -eq 'x64' } | Sort-Object ProductVersion | Select-Object -last 1
-    $EdgeLatestStableVersion = $latestrelease.ProductVersion
-    $policyfiles = ($content | Where-Object { $_.Product -eq 'Policy' }).releases
-    $latestPolicyFile = $policyfiles | Where-Object { $_.ProductVersion -eq $EdgeLatestStableVersion }
-    If (-not($latestPolicyFile)) {   
-        $latestpolicyfile = $policyfiles | Sort-Object ProductVersion | Select-Object -last 1
-    }  
-    $EdgeTemplatesUrl = $latestpolicyfile.artifacts.Location
-    If ($null -eq $EdgeTemplatesUrl) {
-        Write-Log -Category Warning -Message "Unable to get download Url for Edge Policy Templates."
-    } Else {
-        Write-Log -Category Info -Message "Getting download Urls for latest Edge browser and policy templates from '$APIUrl'."
-        $EdgeTemplatesCab = Get-InternetFile -Url $EdgeTemplatesUrl -OutputDirectory $Script:TempDir -Verbose
+    try {
+        $APIUrl = "https://edgeupdates.microsoft.com/api/products?view=enterprise"
+        $EdgeUpdatesJSON = Invoke-WebRequest -Uri $APIUrl -UseBasicParsing
+        $content = $EdgeUpdatesJSON.content | ConvertFrom-Json      
+        $Edgereleases = ($content | Where-Object { $_.Product -eq 'Stable' }).releases
+        $latestrelease = $Edgereleases | Where-Object { $_.Platform -eq 'Windows' -and $_.Architecture -eq 'x64' } | Sort-Object ProductVersion | Select-Object -last 1
+        $EdgeLatestStableVersion = $latestrelease.ProductVersion
+        $policyfiles = ($content | Where-Object { $_.Product -eq 'Policy' }).releases
+        $latestPolicyFile = $policyfiles | Where-Object { $_.ProductVersion -eq $EdgeLatestStableVersion }
+        If (-not($latestPolicyFile)) {   
+            $latestpolicyfile = $policyfiles | Sort-Object ProductVersion | Select-Object -last 1
+        }  
+        $EdgeTemplatesUrl = $latestpolicyfile.artifacts.Location
+        If ($null -eq $EdgeTemplatesUrl) {
+            Write-Log -Category Warning -Message "Unable to get download Url for Edge Policy Templates."
+        } Else {
+            Write-Log -Category Info -Message "Getting download Urls for latest Edge browser and policy templates from '$APIUrl'."
+            $EdgeTemplatesCab = Get-InternetFile -Url $EdgeTemplatesUrl -OutputDirectory $Script:TempDir -Verbose
+        }
+    } catch {
+        Write-Log -Category Warning -Message "Failed to download Edge policy templates: $_. Continuing without ADMX."
     }
 } Else {
     Write-Log -Category Info -Message "'msedge.admx' already present in PolicyDefinitions and no bundled CAB to apply. Skipping template download."

--- a/customer-examples/artifacts/Configure-Office365Policy/Configure-Office365.ps1
+++ b/customer-examples/artifacts/Configure-Office365Policy/Configure-Office365.ps1
@@ -741,11 +741,15 @@ If ($null -ne $O365TemplatesExe) {
 }
 ElseIf ($Script:O365AdmxMissing) {
     Write-Log -Category Info -Message "Office 365 ADMX templates not found in PolicyDefinitions ($($Script:O365AdmxMissing | Split-Path -Leaf)) and no bundled EXE present. Attempting to download."
-    $WebsiteUrl = "https://www.microsoft.com/en-us/download/details.aspx?id=49030"
-    $SearchString = "admintemplates_x64*.exe"
-    $O365TemplatesDownloadUrl = Get-InternetUrl -WebSiteUrl $WebsiteUrl -SearchString $SearchString
-    If ($O365TemplatesDownloadUrl) {
-        $O365TemplatesExe = Get-InternetFile -Url $O365TemplatesDownloadUrl -OutputDirectory $Script:TempDir
+    try {
+        $WebsiteUrl = "https://www.microsoft.com/en-us/download/details.aspx?id=49030"
+        $SearchString = "admintemplates_x64*.exe"
+        $O365TemplatesDownloadUrl = Get-InternetUrl -WebSiteUrl $WebsiteUrl -SearchString $SearchString
+        If ($O365TemplatesDownloadUrl) {
+            $O365TemplatesExe = Get-InternetFile -Url $O365TemplatesDownloadUrl -OutputDirectory $Script:TempDir
+        }
+    } catch {
+        Write-Log -Category Warning -Message "Failed to download Office 365 policy templates: $_. Continuing without ADMX."
     }
 }
 Else {

--- a/customer-examples/parameters/avdAlerts/avdAlerts.parameters.json
+++ b/customer-examples/parameters/avdAlerts/avdAlerts.parameters.json
@@ -1,0 +1,110 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+
+        // ================================================================
+        // Required Parameters
+        // ================================================================
+
+        "location": {
+            "value": "usgovvirginia"
+        },
+
+        "resourceGroupName": {
+            "value": "rg-avd-alerts-p-ugv"
+        },
+
+        // Set to true only on first deployment. On redeployments the resource
+        // group already exists; leave as false.
+        "createResourceGroup": {
+            "value": true
+        },
+
+        // Resource ID of the Log Analytics Workspace that receives AVD diagnostics
+        // (host pool, session host, connection, and FSLogix event logs).
+        "logAnalyticsWorkspaceResourceId": {
+            "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-avd-monitoring-p-ugv/providers/Microsoft.OperationalInsights/workspaces/law-avd-p-ugv"
+        },
+
+        // Resource ID of an existing Action Group to receive alert emails.
+        // Create the Action Group before deploying this add-on.
+        "actionGroupResourceId": {
+            "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-avd-alerts-p-ugv/providers/Microsoft.Insights/actionGroups/ag-avd-p-ugv"
+        },
+
+        // ================================================================
+        // Host Pools
+        // ================================================================
+
+        // One entry per host pool. hostPoolName is the AVD host pool name (not ID).
+        // vmResourceGroupId is the resource ID of the resource group containing the
+        // session host VMs for that host pool.
+        "hostPoolInfo": {
+            "value": [
+                {
+                    "hostPoolResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-avd-pooled-01-p-ugv/providers/Microsoft.DesktopVirtualization/hostPools/hp-avd-pooled-01",
+                    "vmResourceGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-avd-vms-pooled-01-p-ugv"
+                }
+            ]
+        },
+
+        // ================================================================
+        // Optional: Storage Accounts
+        // ================================================================
+
+        // Resource IDs of Azure Files storage accounts used for FSLogix profiles.
+        // Remove or leave as [] if not using Azure Files.
+        "storageAccountResourceIds": {
+            "value": [
+                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-avd-storage-p-ugv/providers/Microsoft.Storage/storageAccounts/stavdprofilesp01"
+            ]
+        },
+
+        // ================================================================
+        // Optional: Azure NetApp Files Volumes
+        // ================================================================
+
+        // Resource IDs of ANF volumes used for FSLogix profiles.
+        // Remove or leave as [] if not using ANF.
+        "anfVolumeResourceIds": {
+            "value": []
+        },
+
+        // ================================================================
+        // Naming / Environment
+        // ================================================================
+
+        "environmentTag": {
+            "value": "p"
+        },
+
+        "alertNamePrefix": {
+            "value": "AVD"
+        },
+
+        "tags": {
+            "value": {
+                "environment": "production",
+                "workload": "avd"
+            }
+        },
+
+        // ================================================================
+        // Automation Account / Runbooks
+        // ================================================================
+
+        // For air-gapped clouds (Secret / Top Secret), set these to empty strings.
+        // The runbooks will be created in an unpublished state and must be published
+        // manually via the Portal before the first scheduled run.
+        // For Azure Commercial and Government, leave these at their default values.
+        //
+        // "runbookContentUriHostPool": { "value": "" },
+        // "runbookContentUriStorage":  { "value": "" },
+
+        // Set to true on first deployment, false on redeployments.
+        "createJobSchedules": {
+            "value": true
+        }
+    }
+}

--- a/deployments/add-ons/avdAlerts/main.bicep
+++ b/deployments/add-ons/avdAlerts/main.bicep
@@ -1,0 +1,378 @@
+// AVD Alerts Add-On
+//
+// Subscription-scoped deployment. Deploys:
+//
+//   - Automation Account (Basic SKU) with system-assigned identity in the specified resource group.
+//     Two runbooks: AvdHostPoolLogData and AvdStorageLogData (storage runbook only when
+//     StorageAccountResourceIds is provided). Runbooks run every 15 minutes and write
+//     pipe/comma-delimited output to the Automation Account job stream, which Log Analytics
+//     collects via diagnostic settings.
+//
+//   - Per-host-pool alert rules (Log Analytics scheduled query rules) for each entry in HostPoolInfo:
+//       capacity %, personal VM unhealthy, no resources available, VM health check failure,
+//       user connection failures, disconnected sessions > 24h / 72h,
+//       local disk free space <= 10% / 5%,
+//       FSLogix profile full (EventID 33/34), network issue (43), VHD attach failure (52/40),
+//       service disabled (60), compaction failed (62/63), VHD in use by another VM (51).
+//
+//   - Per-host-pool VM metric alert rules (multi-resource, scoped to each VM resource group):
+//       CPU > 85%/95%, Available Memory < 2GB/1GB, OS Disk Bandwidth > 85%/95%.
+//
+//   - Per-storage-account metric alert rules (optional):
+//       SuccessServerLatency > 50ms/100ms, SuccessE2ELatency > 50ms/100ms,
+//       Availability < 99%, file share throttling.
+//       Log-based storage space alerts <= 15%/5% (one set, driven by the storage runbook).
+//
+//   - Per-ANF-volume metric alert rules (optional):
+//       VolumeConsumedSizePercentage >= 85%/95%.
+//
+//   - Service Health activity log alerts (subscription-scoped):
+//       Incident, Maintenance, Health Advisory, Security.
+//
+// Role assignments granted to the Automation Account managed identity:
+//   - Desktop Virtualization Reader on the subscription (to enumerate host pools and sessions)
+//   - Log Analytics Contributor on the Log Analytics workspace resource group
+//   - Storage Account Contributor on each storage account resource group (when applicable)
+//
+// Air-gapped environments: set runbookContentUriHostPool and runbookContentUriStorage to empty
+//   strings to skip automatic runbook publishing. The Automation Account is created with the
+//   runbooks in an unpublished state. Publish manually via the Portal before the first run.
+
+targetScope = 'subscription'
+
+// ========== //
+// Parameters //
+// ========== //
+
+// ================================================================================================
+// Identity / Common
+// ================================================================================================
+
+@description('Required. Azure region for the Automation Account and alert rule resources.')
+param location string
+
+@description('Optional. Tags applied to all resources.')
+param tags object = {}
+
+@description('Optional. Prefix for all alert rule names (e.g. "AVD").')
+param alertNamePrefix string = 'AVD'
+
+@description('Optional. Whether alert rules should auto-resolve when the condition clears.')
+param autoResolveAlert bool = true
+
+// ================================================================================================
+// Resource Group
+// ================================================================================================
+
+@description('Required. Name of the resource group where the Automation Account and alert resources will be deployed.')
+param resourceGroupName string
+
+@description('Optional. Set to true to create the resource group. Set to false if it already exists.')
+param createResourceGroup bool = false
+
+// ================================================================================================
+// Monitoring
+// ================================================================================================
+
+@description('Required. Resource ID of the Log Analytics Workspace where AVD diagnostic data is collected.')
+param logAnalyticsWorkspaceResourceId string
+
+@description('Required. Resource ID of the existing Action Group to receive alert notifications.')
+param actionGroupResourceId string
+
+// ================================================================================================
+// Host Pools
+// ================================================================================================
+
+@description('''Required. Array of host pool objects, one per host pool to monitor.
+Each object must have the following properties:
+  hostPoolResourceId:  string  - Full resource ID of the AVD host pool.
+  vmResourceGroupId:   string  - Resource ID of the resource group containing the session host VMs.
+
+Example:
+[
+  { "hostPoolResourceId": "/subscriptions/.../resourceGroups/rg-avd-01/providers/Microsoft.DesktopVirtualization/hostPools/hp-avd-pooled-01", "vmResourceGroupId": "/subscriptions/.../resourceGroups/rg-avd-vms-01" }
+  { "hostPoolResourceId": "/subscriptions/.../resourceGroups/rg-avd-02/providers/Microsoft.DesktopVirtualization/hostPools/hp-avd-personal-01", "vmResourceGroupId": "/subscriptions/.../resourceGroups/rg-avd-vms-02" }
+]
+''')
+param hostPoolInfo array
+
+// ================================================================================================
+// Storage (optional)
+// ================================================================================================
+
+@description('Optional. Resource IDs of Azure Files storage accounts used for FSLogix profile storage. When provided, metric and log-based storage alerts are deployed.')
+param storageAccountResourceIds array = []
+
+// ================================================================================================
+// Azure NetApp Files (optional)
+// ================================================================================================
+
+@description('Optional. Resource IDs of Azure NetApp Files volumes used for FSLogix profile storage. When provided, ANF volume capacity alerts are deployed.')
+param anfVolumeResourceIds array = []
+
+// ================================================================================================
+// Automation Account / Runbooks
+// ================================================================================================
+
+@description('Optional. Explicit name override for the Automation Account. When empty, the auto-generated name is used: aa-avd-alerts-{regionAbbr}.')
+param automationAccountNameOverride string = ''
+
+
+@description('''Optional. URI of the AvdStorageLogData runbook PS1 file.
+Defaults to the public FederalAVD GitHub repository.
+
+For air-gapped or internet-restricted environments, set this to empty (\'\') to skip automatic
+publishing. The runbook will be created in an unpublished (New) state and must be published
+manually via the Portal before the first scheduled run.''')
+param runbookContentUriStorage string = 'https://raw.githubusercontent.com/Azure/FederalAVD/main/deployments/add-ons/avdAlerts/scripts/Get-StorAcctInfo.ps1'
+
+@description('Optional. UTC timestamp used to compute the first schedule start time. Defaults to deployment time.')
+param deploymentTime string = utcNow()
+
+@description('''Optional. Set to true on first deployment to let ARM create the job schedule links.
+Set to false on all redeployments. Azure Automation caches job schedule associations by account name
+and raises a Conflict error if ARM tries to create a link that already exists.''')
+param createJobSchedules bool = true
+
+// ================================================================================================
+// Alert Category Enable/Disable
+// ================================================================================================
+
+@description('Optional. When false, host pool capacity alert rules (50%, 85%, 95%) are not deployed.')
+param enableCapacityAlerts bool = true
+
+@description('Optional. When false, host availability and VM health alert rules are not deployed.')
+param enableAvailabilityAlerts bool = true
+
+@description('Optional. When false, user connection failure and disconnected session alert rules are not deployed.')
+param enableConnectionAlerts bool = true
+
+@description('Optional. When false, session host local disk free-space alert rules are not deployed.')
+param enableLocalDiskAlerts bool = true
+
+@description('Optional. When false, FSLogix profile alert rules are not deployed.')
+param enableFslogixAlerts bool = true
+
+@description('Optional. When false, session host VM CPU alert rules are not deployed.')
+param enableCpuAlerts bool = true
+
+@description('Optional. When false, session host VM available memory alert rules are not deployed.')
+param enableMemoryAlerts bool = true
+
+@description('Optional. When false, session host VM OS disk bandwidth alert rules are not deployed.')
+param enableOsDiskAlerts bool = true
+
+@description('Optional. When false, Azure Files storage latency alert rules are not deployed.')
+param enableStorageLatencyAlerts bool = true
+
+@description('Optional. When false, Azure Files storage availability alert rules are not deployed.')
+param enableStorageAvailabilityAlerts bool = true
+
+@description('Optional. When false, Azure Files file share throttling alert rules are not deployed.')
+param enableStorageThrottlingAlerts bool = true
+
+@description('Optional. When false, ANF volume capacity alert rules are not deployed.')
+param enableAnfCapacityAlerts bool = true
+
+@description('Optional. When false, Azure Service Health activity log alert rules are not deployed.')
+param enableServiceHealthAlerts bool = true
+
+// ========== //
+// Variables  //
+// ========== //
+
+var cloud                 = toLower(az.environment().name)
+var locationsObject       = loadJsonContent('../../../.common/data/locations.json')
+var locationsEnvProperty  = startsWith(cloud, 'us') ? 'other' : cloud
+var locations             = locationsObject[locationsEnvProperty]
+var regionAbbr            = locations[location].abbreviation
+var resourceAbbreviations = loadJsonContent('../../../.common/data/resourceAbbreviations.json')
+
+var automationAccountName = !empty(automationAccountNameOverride)
+  ? automationAccountNameOverride
+  : '${resourceAbbreviations.automationAccounts}-avd-alerts-${regionAbbr}'
+
+var hasStorageAccounts = !empty(storageAccountResourceIds)
+
+// Build a JSON array string of storage account resource IDs for the automation variable
+var storageAccountResourceIdsJson = string(storageAccountResourceIds)
+
+// Extract unique storage resource group pairs: subscriptionId,resourceGroupName
+var storageRgPairs = [for id in storageAccountResourceIds: '${split(id, '/')[2]},${split(id, '/')[4]}']
+
+var deploymentSuffix = take(uniqueString(subscription().subscriptionId, resourceGroupName, deployment().name), 8)
+
+var lawSubscriptionId = split(logAnalyticsWorkspaceResourceId, '/')[2]
+var lawResourceGroup  = split(logAnalyticsWorkspaceResourceId, '/')[4]
+
+// Deduplicate hostPoolInfo by hostPoolResourceId (keep first occurrence of each)
+var hostPoolInfoDeduped = reduce(
+  hostPoolInfo,
+  [],
+  (acc, item) => contains(map(acc, (e) => e.hostPoolResourceId), item.hostPoolResourceId) ? acc : concat(acc, [item])
+)
+
+// ========== //
+// Resources  //
+// ========== //
+
+// ------------------------------------------------------------------------------------------------
+// Resource Group
+// ------------------------------------------------------------------------------------------------
+
+resource newResourceGroup 'Microsoft.Resources/resourceGroups@2022-09-01' = if (createResourceGroup) {
+  name: resourceGroupName
+  location: location
+  tags: tags
+}
+
+resource existingResourceGroup 'Microsoft.Resources/resourceGroups@2022-09-01' existing = if (!createResourceGroup) {
+  name: resourceGroupName
+}
+
+// ------------------------------------------------------------------------------------------------
+// Automation Account
+// ------------------------------------------------------------------------------------------------
+
+module automationAccountDeploy 'modules/automationAccount.bicep' = if (hasStorageAccounts) {
+  name: 'AvdAlerts-AutomationAccount-${deploymentSuffix}'
+  scope: resourceGroup(resourceGroupName)
+  params: {
+    automationAccountName: automationAccountName
+    location: location
+    tags: tags
+    resourceManagerUri: az.environment().resourceManager
+    logAnalyticsWorkspaceResourceId: logAnalyticsWorkspaceResourceId
+    runbookStorageUri: runbookContentUriStorage
+    hasStorageAccounts: hasStorageAccounts
+    storageAccountResourceIdsJson: storageAccountResourceIdsJson
+    deploymentTime: deploymentTime
+    createJobSchedules: createJobSchedules
+  }
+  dependsOn: createResourceGroup ? [newResourceGroup] : [existingResourceGroup]
+}
+
+// ------------------------------------------------------------------------------------------------
+// Role Assignments for Automation Account Managed Identity
+// ------------------------------------------------------------------------------------------------
+
+// Log Analytics Contributor - on the LAW resource group
+module roleAssignLogAnalytics 'modules/roleAssignment.bicep' = if (hasStorageAccounts) {
+  name: 'AvdAlerts-RoleAssign-LAW-${deploymentSuffix}'
+  scope: resourceGroup(lawSubscriptionId, lawResourceGroup)
+  params: {
+    #disable-next-line BCP318
+    principalId: automationAccountDeploy.outputs.principalId!
+    roleDefinitionId: '92aaf0da-9dab-42b6-94a3-d43ce8d16293'
+    resourceGroupName: lawResourceGroup
+    nameSuffix: automationAccountName
+  }
+}
+
+// Storage Account Contributor - on each unique storage resource group
+module roleAssignStorage 'modules/roleAssignment.bicep' = [for (rgPair, i) in storageRgPairs: {
+  name: 'AvdAlerts-RoleAssign-Stor${i}-${deploymentSuffix}'
+  scope: resourceGroup(split(rgPair, ',')[0], split(rgPair, ',')[1])
+  params: {
+    #disable-next-line BCP318
+    principalId: automationAccountDeploy.outputs.principalId!
+    roleDefinitionId: '17d1049b-9a84-46fb-8f53-869881c3d3ab'
+    resourceGroupName: split(rgPair, ',')[1]
+    nameSuffix: '${automationAccountName}-stor${i}'
+  }
+}]
+
+// ------------------------------------------------------------------------------------------------
+// Per-Host-Pool Alert Rules
+// ------------------------------------------------------------------------------------------------
+
+module hostPoolLogAlerts 'modules/hostPoolAlerts.bicep' = [for hp in hostPoolInfoDeduped: {
+  name: 'AvdAlerts-HP-${last(split(hp.hostPoolResourceId, '/'))}-${deploymentSuffix}'
+  scope: resourceGroup(resourceGroupName)
+  params: {
+    hostPoolName: last(split(hp.hostPoolResourceId, '/'))
+    logAnalyticsWorkspaceResourceId: logAnalyticsWorkspaceResourceId
+    actionGroupResourceId: actionGroupResourceId
+    alertNamePrefix: alertNamePrefix
+    autoResolveAlert: autoResolveAlert
+    location: location
+    enableCapacityAlerts: enableCapacityAlerts
+    enableAvailabilityAlerts: enableAvailabilityAlerts
+    enableConnectionAlerts: enableConnectionAlerts
+    enableLocalDiskAlerts: enableLocalDiskAlerts
+    enableFslogixAlerts: enableFslogixAlerts
+  }
+  dependsOn: createResourceGroup ? [newResourceGroup] : [existingResourceGroup]
+}]
+
+// Per-host-pool VM metric alerts (multi-resource, scoped to VM resource group)
+module vmMetricAlerts 'modules/vmMetricAlerts.bicep' = [for hp in hostPoolInfoDeduped: {
+  name: 'AvdAlerts-VMMetrics-${last(split(hp.hostPoolResourceId, '/'))}-${deploymentSuffix}'
+  scope: resourceGroup(split(hp.vmResourceGroupId, '/')[2], split(hp.vmResourceGroupId, '/')[4])
+  params: {
+    hostPoolName: last(split(hp.hostPoolResourceId, '/'))
+    vmResourceGroupId: hp.vmResourceGroupId
+    actionGroupResourceId: actionGroupResourceId
+    alertNamePrefix: alertNamePrefix
+    autoResolveAlert: autoResolveAlert
+    location: location
+    enableCpuAlerts: enableCpuAlerts
+    enableMemoryAlerts: enableMemoryAlerts
+    enableOsDiskAlerts: enableOsDiskAlerts
+  }
+}]
+
+// ------------------------------------------------------------------------------------------------
+// Storage Alert Rules
+// ------------------------------------------------------------------------------------------------
+
+module storageAlerts 'modules/storageAlerts.bicep' = [for (storId, i) in storageAccountResourceIds: {
+  name: 'AvdAlerts-Stor${i}-${deploymentSuffix}'
+  scope: resourceGroup(split(storId, '/')[2], split(storId, '/')[4])
+  params: {
+    storageAccountResourceId: storId
+    actionGroupResourceId: actionGroupResourceId
+    alertNamePrefix: alertNamePrefix
+    autoResolveAlert: autoResolveAlert
+    location: location
+    logAnalyticsWorkspaceResourceId: logAnalyticsWorkspaceResourceId
+    // Only create the log-based space alert rules once (on the first storage account)
+    createStorageLogAlerts: i == 0
+    enableStorageLatencyAlerts: enableStorageLatencyAlerts
+    enableStorageAvailabilityAlerts: enableStorageAvailabilityAlerts
+    enableStorageThrottlingAlerts: enableStorageThrottlingAlerts
+  }
+  dependsOn: i == 0 && createResourceGroup ? [newResourceGroup] : []
+}]
+
+// ------------------------------------------------------------------------------------------------
+// ANF Volume Alert Rules
+// ------------------------------------------------------------------------------------------------
+
+module anfAlerts 'modules/anfAlerts.bicep' = [for (anfId, i) in anfVolumeResourceIds: {
+  name: 'AvdAlerts-ANF${i}-${deploymentSuffix}'
+  scope: resourceGroup(split(anfId, '/')[2], split(anfId, '/')[4])
+  params: {
+    anfVolumeResourceId: anfId
+    actionGroupResourceId: actionGroupResourceId
+    alertNamePrefix: alertNamePrefix
+    autoResolveAlert: autoResolveAlert
+    enableAnfCapacityAlerts: enableAnfCapacityAlerts
+  }
+}]
+
+// ------------------------------------------------------------------------------------------------
+// Service Health Alert Rules
+// ------------------------------------------------------------------------------------------------
+
+module serviceHealthAlerts 'modules/serviceHealthAlerts.bicep' = {
+  name: 'AvdAlerts-SvcHealth-${deploymentSuffix}'
+  scope: resourceGroup(resourceGroupName)
+  params: {
+    actionGroupResourceId: actionGroupResourceId
+    alertNamePrefix: alertNamePrefix
+    enableServiceHealthAlerts: enableServiceHealthAlerts
+  }
+  dependsOn: createResourceGroup ? [newResourceGroup] : [existingResourceGroup]
+}

--- a/deployments/add-ons/avdAlerts/main.json
+++ b/deployments/add-ons/avdAlerts/main.json
@@ -1,0 +1,3570 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.39.26.7824",
+      "templateHash": "7884161572304755827"
+    }
+  },
+  "parameters": {
+    "location": {
+      "type": "string",
+      "metadata": {
+        "description": "Required. Azure region for the Automation Account and alert rule resources."
+      }
+    },
+    "tags": {
+      "type": "object",
+      "defaultValue": {},
+      "metadata": {
+        "description": "Optional. Tags applied to all resources."
+      }
+    },
+    "alertNamePrefix": {
+      "type": "string",
+      "defaultValue": "AVD",
+      "metadata": {
+        "description": "Optional. Prefix for all alert rule names (e.g. \"AVD\")."
+      }
+    },
+    "autoResolveAlert": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Optional. Whether alert rules should auto-resolve when the condition clears."
+      }
+    },
+    "resourceGroupName": {
+      "type": "string",
+      "metadata": {
+        "description": "Required. Name of the resource group where the Automation Account and alert resources will be deployed."
+      }
+    },
+    "createResourceGroup": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Optional. Set to true to create the resource group. Set to false if it already exists."
+      }
+    },
+    "logAnalyticsWorkspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Required. Resource ID of the Log Analytics Workspace where AVD diagnostic data is collected."
+      }
+    },
+    "actionGroupResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Required. Resource ID of the existing Action Group to receive alert notifications."
+      }
+    },
+    "hostPoolInfo": {
+      "type": "array",
+      "metadata": {
+        "description": "Required. Array of host pool objects, one per host pool to monitor.\nEach object must have the following properties:\n  hostPoolResourceId:  string  - Full resource ID of the AVD host pool.\n  vmResourceGroupId:   string  - Resource ID of the resource group containing the session host VMs.\n\nExample:\n[\n  { \"hostPoolResourceId\": \"/subscriptions/.../resourceGroups/rg-avd-01/providers/Microsoft.DesktopVirtualization/hostPools/hp-avd-pooled-01\", \"vmResourceGroupId\": \"/subscriptions/.../resourceGroups/rg-avd-vms-01\" }\n  { \"hostPoolResourceId\": \"/subscriptions/.../resourceGroups/rg-avd-02/providers/Microsoft.DesktopVirtualization/hostPools/hp-avd-personal-01\", \"vmResourceGroupId\": \"/subscriptions/.../resourceGroups/rg-avd-vms-02\" }\n]\n"
+      }
+    },
+    "storageAccountResourceIds": {
+      "type": "array",
+      "defaultValue": [],
+      "metadata": {
+        "description": "Optional. Resource IDs of Azure Files storage accounts used for FSLogix profile storage. When provided, metric and log-based storage alerts are deployed."
+      }
+    },
+    "anfVolumeResourceIds": {
+      "type": "array",
+      "defaultValue": [],
+      "metadata": {
+        "description": "Optional. Resource IDs of Azure NetApp Files volumes used for FSLogix profile storage. When provided, ANF volume capacity alerts are deployed."
+      }
+    },
+    "automationAccountNameOverride": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Optional. Explicit name override for the Automation Account. When empty, the auto-generated name is used: aa-avd-alerts-{regionAbbr}."
+      }
+    },
+    "runbookContentUriStorage": {
+      "type": "string",
+      "defaultValue": "https://raw.githubusercontent.com/Azure/FederalAVD/main/deployments/add-ons/avdAlerts/scripts/Get-StorAcctInfo.ps1",
+      "metadata": {
+        "description": "Optional. URI of the AvdStorageLogData runbook PS1 file.\nDefaults to the public FederalAVD GitHub repository.\n\nFor air-gapped or internet-restricted environments, set this to empty (\\'\\') to skip automatic\npublishing. The runbook will be created in an unpublished (New) state and must be published\nmanually via the Portal before the first scheduled run."
+      }
+    },
+    "deploymentTime": {
+      "type": "string",
+      "defaultValue": "[utcNow()]",
+      "metadata": {
+        "description": "Optional. UTC timestamp used to compute the first schedule start time. Defaults to deployment time."
+      }
+    },
+    "createJobSchedules": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Optional. Set to true on first deployment to let ARM create the job schedule links.\nSet to false on all redeployments. Azure Automation caches job schedule associations by account name\nand raises a Conflict error if ARM tries to create a link that already exists."
+      }
+    },
+    "enableCapacityAlerts": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Optional. When false, host pool capacity alert rules (50%, 85%, 95%) are not deployed."
+      }
+    },
+    "enableAvailabilityAlerts": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Optional. When false, host availability and VM health alert rules are not deployed."
+      }
+    },
+    "enableConnectionAlerts": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Optional. When false, user connection failure and disconnected session alert rules are not deployed."
+      }
+    },
+    "enableLocalDiskAlerts": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Optional. When false, session host local disk free-space alert rules are not deployed."
+      }
+    },
+    "enableFslogixAlerts": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Optional. When false, FSLogix profile alert rules are not deployed."
+      }
+    },
+    "enableCpuAlerts": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Optional. When false, session host VM CPU alert rules are not deployed."
+      }
+    },
+    "enableMemoryAlerts": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Optional. When false, session host VM available memory alert rules are not deployed."
+      }
+    },
+    "enableOsDiskAlerts": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Optional. When false, session host VM OS disk bandwidth alert rules are not deployed."
+      }
+    },
+    "enableStorageLatencyAlerts": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Optional. When false, Azure Files storage latency alert rules are not deployed."
+      }
+    },
+    "enableStorageAvailabilityAlerts": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Optional. When false, Azure Files storage availability alert rules are not deployed."
+      }
+    },
+    "enableStorageThrottlingAlerts": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Optional. When false, Azure Files file share throttling alert rules are not deployed."
+      }
+    },
+    "enableAnfCapacityAlerts": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Optional. When false, ANF volume capacity alert rules are not deployed."
+      }
+    },
+    "enableServiceHealthAlerts": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Optional. When false, Azure Service Health activity log alert rules are not deployed."
+      }
+    }
+  },
+  "variables": {
+    "copy": [
+      {
+        "name": "storageRgPairs",
+        "count": "[length(parameters('storageAccountResourceIds'))]",
+        "input": "[format('{0},{1}', split(parameters('storageAccountResourceIds')[copyIndex('storageRgPairs')], '/')[2], split(parameters('storageAccountResourceIds')[copyIndex('storageRgPairs')], '/')[4])]"
+      }
+    ],
+    "$fxv#0": {
+      "AzureCloud": {
+        "australiacentral": {
+          "abbreviation": "auc",
+          "recoveryServicesGeo": "acl"
+        },
+        "australiacentral2": {
+          "abbreviation": "auc2",
+          "recoveryServicesGeo": "acl2"
+        },
+        "australiaeast": {
+          "abbreviation": "aue",
+          "recoveryServicesGeo": "ae"
+        },
+        "australiasoutheast": {
+          "abbreviation": "ause",
+          "recoveryServicesGeo": "ase"
+        },
+        "brazilsouth": {
+          "abbreviation": "brs",
+          "recoveryServicesGeo": "brs"
+        },
+        "brazilsoutheast": {
+          "abbreviation": "brse",
+          "recoveryServicesGeo": "bse"
+        },
+        "canadacentral": {
+          "abbreviation": "cac",
+          "recoveryServicesGeo": "cnc"
+        },
+        "canadaeast": {
+          "abbreviation": "cae",
+          "recoveryServicesGeo": "cne"
+        },
+        "centralindia": {
+          "abbreviation": "inc",
+          "recoveryServicesGeo": "inc"
+        },
+        "centralus": {
+          "abbreviation": "usc",
+          "recoveryServicesGeo": "cus"
+        },
+        "eastasia": {
+          "abbreviation": "ase",
+          "recoveryServicesGeo": "ea"
+        },
+        "eastus": {
+          "abbreviation": "use",
+          "recoveryServicesGeo": "eus"
+        },
+        "eastus2": {
+          "abbreviation": "use2",
+          "recoveryServicesGeo": "eus2"
+        },
+        "francecentral": {
+          "abbreviation": "frc",
+          "recoveryServicesGeo": "frc"
+        },
+        "francesouth": {
+          "abbreviation": "frs",
+          "recoveryServicesGeo": "frs"
+        },
+        "germanynorth": {
+          "abbreviation": "den",
+          "recoveryServicesGeo": "gn"
+        },
+        "germanywestcentral": {
+          "abbreviation": "dewc",
+          "recoveryServicesGeo": "gwc"
+        },
+        "israelcentral": {
+          "abbreviation": "ilc",
+          "recoveryServicesGeo": "ilc"
+        },
+        "italynorth": {
+          "abbreviation": "itn",
+          "recoveryServicesGeo": "itn"
+        },
+        "japaneast": {
+          "abbreviation": "jpe",
+          "recoveryServicesGeo": "jpe"
+        },
+        "japanwest": {
+          "abbreviation": "jpw",
+          "recoveryServicesGeo": "jpw"
+        },
+        "jioindiacentral": {
+          "abbreviation": "injc",
+          "recoveryServicesGeo": "jic"
+        },
+        "jioindiawest": {
+          "abbreviation": "injw",
+          "recoveryServicesGeo": "jiw"
+        },
+        "koreacentral": {
+          "abbreviation": "krc",
+          "recoveryServicesGeo": "krc"
+        },
+        "koreasouth": {
+          "abbreviation": "krs",
+          "recoveryServicesGeo": "krs"
+        },
+        "northcentralus": {
+          "abbreviation": "usnc",
+          "recoveryServicesGeo": "ncus"
+        },
+        "northeurope": {
+          "abbreviation": "eun",
+          "recoveryServicesGeo": "ne"
+        },
+        "norwayeast": {
+          "abbreviation": "noe",
+          "recoveryServicesGeo": "nwe"
+        },
+        "norwaywest": {
+          "abbreviation": "now",
+          "recoveryServicesGeo": "nww"
+        },
+        "polandcentral": {
+          "abbreviation": "plc",
+          "recoveryServicesGeo": "plc"
+        },
+        "qatarcentral": {
+          "abbreviation": "qac",
+          "recoveryServicesGeo": "qac"
+        },
+        "southafricanorth": {
+          "abbreviation": "zan",
+          "recoveryServicesGeo": "san"
+        },
+        "southafricawest": {
+          "abbreviation": "zaw",
+          "recoveryServicesGeo": "saw"
+        },
+        "southcentralus": {
+          "abbreviation": "ussc",
+          "recoveryServicesGeo": "scus"
+        },
+        "southeastasia": {
+          "abbreviation": "asse",
+          "recoveryServicesGeo": "sea"
+        },
+        "southindia": {
+          "abbreviation": "ins",
+          "recoveryServicesGeo": "ins"
+        },
+        "swedencentral": {
+          "abbreviation": "sec",
+          "recoveryServicesGeo": "sdc"
+        },
+        "switzerlandnorth": {
+          "abbreviation": "chn",
+          "recoveryServicesGeo": "szn"
+        },
+        "switzerlandwest": {
+          "abbreviation": "chw",
+          "recoveryServicesGeo": "szw"
+        },
+        "uaecentral": {
+          "abbreviation": "aec",
+          "recoveryServicesGeo": "uac"
+        },
+        "uaenorth": {
+          "abbreviation": "aen",
+          "recoveryServicesGeo": "uan"
+        },
+        "uksouth": {
+          "abbreviation": "uks",
+          "recoveryServicesGeo": "uks"
+        },
+        "ukwest": {
+          "abbreviation": "ukw",
+          "recoveryServicesGeo": "ukw"
+        },
+        "westcentralus": {
+          "abbreviation": "uswc",
+          "recoveryServicesGeo": "wcus"
+        },
+        "westeurope": {
+          "abbreviation": "euw",
+          "recoveryServicesGeo": "we"
+        },
+        "westindia": {
+          "abbreviation": "inw",
+          "recoveryServicesGeo": "inw"
+        },
+        "westus": {
+          "abbreviation": "usw",
+          "recoveryServicesGeo": "wus"
+        },
+        "westus2": {
+          "abbreviation": "usw2",
+          "recoveryServicesGeo": "wus2"
+        },
+        "westus3": {
+          "abbreviation": "usw3",
+          "recoveryServicesGeo": "wus3"
+        }
+      },
+      "AzureUSGovernment": {
+        "usdodcentral": {
+          "abbreviation": "dodc",
+          "recoveryServicesGeo": "udc"
+        },
+        "usdodeast": {
+          "abbreviation": "dode",
+          "recoveryServicesGeo": "ude"
+        },
+        "usgovarizona": {
+          "abbreviation": "az",
+          "recoveryServicesGeo": "uga"
+        },
+        "usgovtexas": {
+          "abbreviation": "tx",
+          "recoveryServicesGeo": "ugt"
+        },
+        "usgovvirginia": {
+          "abbreviation": "va",
+          "recoveryServicesGeo": "ugv"
+        }
+      },
+      "other": {
+        "north": {
+          "abbreviation": "no"
+        },
+        "east": {
+          "abbreviation": "ea"
+        },
+        "south": {
+          "abbreviation": "so"
+        },
+        "west": {
+          "abbreviation": "we"
+        },
+        "central": {
+          "abbreviation": "ce"
+        },
+        "northcentral": {
+          "abbreviation": "noce"
+        },
+        "eastcentral": {
+          "abbreviation": "wece"
+        },
+        "southcentral": {
+          "abbreviation": "soce"
+        },
+        "westcentral": {
+          "abbreviation": "wece"
+        }
+      }
+    },
+    "$fxv#1": {
+      "applicationInsights": "appi",
+      "appServicePlans": "asp",
+      "automationAccounts": "aa",
+      "availabilitySets": "as",
+      "computeGalleries": "gal",
+      "dataCollectionEndpoints": "dce",
+      "dataCollectionRules": "dcr",
+      "desktopApplicationGroups": "vddag",
+      "diskAccesses": "da",
+      "remoteApplicationGroups": "vdrag",
+      "diskEncryptionSets": "des",
+      "functionApps": "fa",
+      "hostPools": "vdpool",
+      "keyVaults": "kv",
+      "logAnalyticsWorkspaces": "law",
+      "natGateways": "ng",
+      "netAppAccounts": "naa",
+      "netAppCapacityPools": "nacp",
+      "networkInterfaces": "nic",
+      "networkSecurityGroups": "nsg",
+      "osdisks": "disk",
+      "privateEndpoints": "pe",
+      "privateLinkScopes": "pls",
+      "publicIPAddresses": "pip",
+      "recoveryServicesVaults": "rsv",
+      "resourceGroups": "rg",
+      "routeTables": "rt",
+      "scalingPlans": "vdscaling",
+      "storageAccounts": "sa",
+      "templateSpecs": "ts",
+      "userAssignedIdentities": "uai",
+      "virtualMachines": "vm",
+      "workbooks": "wb",
+      "workspaces": "vdws",
+      "imageDefinitions": "vmid"
+    },
+    "cloud": "[toLower(environment().name)]",
+    "locationsObject": "[variables('$fxv#0')]",
+    "locationsEnvProperty": "[if(startsWith(variables('cloud'), 'us'), 'other', variables('cloud'))]",
+    "locations": "[variables('locationsObject')[variables('locationsEnvProperty')]]",
+    "regionAbbr": "[variables('locations')[parameters('location')].abbreviation]",
+    "resourceAbbreviations": "[variables('$fxv#1')]",
+    "automationAccountName": "[if(not(empty(parameters('automationAccountNameOverride'))), parameters('automationAccountNameOverride'), format('{0}-avd-alerts-{1}', variables('resourceAbbreviations').automationAccounts, variables('regionAbbr')))]",
+    "hasStorageAccounts": "[not(empty(parameters('storageAccountResourceIds')))]",
+    "storageAccountResourceIdsJson": "[string(parameters('storageAccountResourceIds'))]",
+    "deploymentSuffix": "[take(uniqueString(subscription().subscriptionId, parameters('resourceGroupName'), deployment().name), 8)]",
+    "lawSubscriptionId": "[split(parameters('logAnalyticsWorkspaceResourceId'), '/')[2]]",
+    "lawResourceGroup": "[split(parameters('logAnalyticsWorkspaceResourceId'), '/')[4]]",
+    "hostPoolInfoDeduped": "[reduce(parameters('hostPoolInfo'), createArray(), lambda('acc', 'item', if(contains(map(lambdaVariables('acc'), lambda('e', lambdaVariables('e').hostPoolResourceId)), lambdaVariables('item').hostPoolResourceId), lambdaVariables('acc'), concat(lambdaVariables('acc'), createArray(lambdaVariables('item'))))))]"
+  },
+  "resources": [
+    {
+      "condition": "[parameters('createResourceGroup')]",
+      "type": "Microsoft.Resources/resourceGroups",
+      "apiVersion": "2022-09-01",
+      "name": "[parameters('resourceGroupName')]",
+      "location": "[parameters('location')]",
+      "tags": "[parameters('tags')]"
+    },
+    {
+      "condition": "[variables('hasStorageAccounts')]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('AvdAlerts-AutomationAccount-{0}', variables('deploymentSuffix'))]",
+      "resourceGroup": "[parameters('resourceGroupName')]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "automationAccountName": {
+            "value": "[variables('automationAccountName')]"
+          },
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "tags": {
+            "value": "[parameters('tags')]"
+          },
+          "resourceManagerUri": {
+            "value": "[environment().resourceManager]"
+          },
+          "logAnalyticsWorkspaceResourceId": {
+            "value": "[parameters('logAnalyticsWorkspaceResourceId')]"
+          },
+          "runbookStorageUri": {
+            "value": "[parameters('runbookContentUriStorage')]"
+          },
+          "hasStorageAccounts": {
+            "value": "[variables('hasStorageAccounts')]"
+          },
+          "storageAccountResourceIdsJson": {
+            "value": "[variables('storageAccountResourceIdsJson')]"
+          },
+          "deploymentTime": {
+            "value": "[parameters('deploymentTime')]"
+          },
+          "createJobSchedules": {
+            "value": "[parameters('createJobSchedules')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.39.26.7824",
+              "templateHash": "9121094106321195839"
+            }
+          },
+          "parameters": {
+            "automationAccountName": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Name of the Automation Account."
+              }
+            },
+            "location": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Azure region for all resources."
+              }
+            },
+            "tags": {
+              "type": "object",
+              "defaultValue": {},
+              "metadata": {
+                "description": "Optional. Tags for all resources."
+              }
+            },
+            "resourceManagerUri": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Azure Resource Manager URI for this cloud (e.g. https://management.azure.com/)."
+              }
+            },
+            "logAnalyticsWorkspaceResourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Resource ID of the Log Analytics Workspace for diagnostic settings and runbook output."
+              }
+            },
+            "runbookStorageUri": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Optional. URI of the AvdStorageLogData runbook PS1 file. Leave empty for air-gapped environments to create the runbook in an unpublished state."
+              }
+            },
+            "hasStorageAccounts": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "Optional. Set to true when StorageAccountResourceIds is not empty."
+              }
+            },
+            "storageAccountResourceIdsJson": {
+              "type": "string",
+              "defaultValue": "[[]",
+              "metadata": {
+                "description": "Optional. JSON array string of storage account resource IDs for the storage runbook."
+              }
+            },
+            "deploymentTime": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. UTC timestamp used to compute the first schedule start time."
+              }
+            },
+            "createJobSchedules": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Set to true on first deployment to let ARM create the job schedule links.\nSet to false on redeployments. Azure Automation caches job schedule associations by account\nname and raises a Conflict error if ARM tries to create a link that already exists."
+              }
+            }
+          },
+          "variables": {
+            "runbookNameStorage": "AvdStorageLogData",
+            "scheduleStorageStart": "[dateTimeAdd(parameters('deploymentTime'), 'PT5M')]"
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Automation/automationAccounts",
+              "apiVersion": "2023-11-01",
+              "name": "[parameters('automationAccountName')]",
+              "location": "[parameters('location')]",
+              "tags": "[parameters('tags')]",
+              "identity": {
+                "type": "SystemAssigned"
+              },
+              "properties": {
+                "sku": {
+                  "name": "Basic"
+                },
+                "publicNetworkAccess": false,
+                "disableLocalAuth": true
+              }
+            },
+            {
+              "type": "Microsoft.Automation/automationAccounts/variables",
+              "apiVersion": "2023-11-01",
+              "name": "[format('{0}/{1}', parameters('automationAccountName'), 'ResourceManagerUri')]",
+              "properties": {
+                "value": "[format('\"{0}\"', parameters('resourceManagerUri'))]",
+                "isEncrypted": false,
+                "description": "Azure Resource Manager endpoint URI for this cloud."
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Automation/automationAccounts', parameters('automationAccountName'))]"
+              ]
+            },
+            {
+              "condition": "[parameters('hasStorageAccounts')]",
+              "type": "Microsoft.Automation/automationAccounts/variables",
+              "apiVersion": "2023-11-01",
+              "name": "[format('{0}/{1}', parameters('automationAccountName'), 'StorageAccountResourceIDs')]",
+              "properties": {
+                "value": "[format('\"{0}\"', replace(parameters('storageAccountResourceIdsJson'), '\"', '\\\"'))]",
+                "isEncrypted": false,
+                "description": "JSON array of storage account resource IDs for the storage space collector."
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Automation/automationAccounts', parameters('automationAccountName'))]"
+              ]
+            },
+            {
+              "condition": "[parameters('hasStorageAccounts')]",
+              "type": "Microsoft.Automation/automationAccounts/runbooks",
+              "apiVersion": "2023-11-01",
+              "name": "[format('{0}/{1}', parameters('automationAccountName'), variables('runbookNameStorage'))]",
+              "location": "[parameters('location')]",
+              "tags": "[parameters('tags')]",
+              "properties": {
+                "runbookType": "PowerShell72",
+                "logVerbose": false,
+                "logProgress": false,
+                "description": "Collects Azure Files share usage statistics for Log Analytics alert queries.",
+                "publishContentLink": "[if(not(empty(parameters('runbookStorageUri'))), createObject('uri', parameters('runbookStorageUri')), null())]"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Automation/automationAccounts', parameters('automationAccountName'))]"
+              ]
+            },
+            {
+              "condition": "[parameters('hasStorageAccounts')]",
+              "type": "Microsoft.Automation/automationAccounts/schedules",
+              "apiVersion": "2023-11-01",
+              "name": "[format('{0}/{1}', parameters('automationAccountName'), 'AvdAlerts-Storage-15min')]",
+              "properties": {
+                "description": "Runs the AVD storage data collector every 15 minutes.",
+                "startTime": "[variables('scheduleStorageStart')]",
+                "frequency": "Minute",
+                "interval": 15,
+                "timeZone": "UTC"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Automation/automationAccounts', parameters('automationAccountName'))]"
+              ]
+            },
+            {
+              "condition": "[and(parameters('hasStorageAccounts'), parameters('createJobSchedules'))]",
+              "type": "Microsoft.Automation/automationAccounts/jobSchedules",
+              "apiVersion": "2023-11-01",
+              "name": "[format('{0}/{1}', parameters('automationAccountName'), guid(resourceId('Microsoft.Automation/automationAccounts', parameters('automationAccountName')), resourceId('Microsoft.Automation/automationAccounts/runbooks', parameters('automationAccountName'), variables('runbookNameStorage')), resourceId('Microsoft.Automation/automationAccounts/schedules', parameters('automationAccountName'), 'AvdAlerts-Storage-15min')))]",
+              "properties": {
+                "runbook": {
+                  "name": "[variables('runbookNameStorage')]"
+                },
+                "schedule": {
+                  "name": "AvdAlerts-Storage-15min"
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Automation/automationAccounts', parameters('automationAccountName'))]",
+                "[resourceId('Microsoft.Automation/automationAccounts/runbooks', parameters('automationAccountName'), variables('runbookNameStorage'))]",
+                "[resourceId('Microsoft.Automation/automationAccounts/schedules', parameters('automationAccountName'), 'AvdAlerts-Storage-15min')]"
+              ]
+            },
+            {
+              "type": "Microsoft.Insights/diagnosticSettings",
+              "apiVersion": "2021-05-01-preview",
+              "scope": "[format('Microsoft.Automation/automationAccounts/{0}', parameters('automationAccountName'))]",
+              "name": "[format('diag-{0}', parameters('automationAccountName'))]",
+              "properties": {
+                "workspaceId": "[parameters('logAnalyticsWorkspaceResourceId')]",
+                "logs": [
+                  {
+                    "category": "JobLogs",
+                    "enabled": true
+                  },
+                  {
+                    "category": "JobStreams",
+                    "enabled": true
+                  }
+                ],
+                "metrics": [
+                  {
+                    "category": "AllMetrics",
+                    "enabled": false
+                  }
+                ]
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Automation/automationAccounts', parameters('automationAccountName'))]"
+              ]
+            }
+          ],
+          "outputs": {
+            "principalId": {
+              "type": "string",
+              "metadata": {
+                "description": "Principal ID of the Automation Account system-assigned managed identity."
+              },
+              "value": "[reference(resourceId('Microsoft.Automation/automationAccounts', parameters('automationAccountName')), '2023-11-01', 'full').identity.principalId]"
+            },
+            "resourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "Resource ID of the Automation Account."
+              },
+              "value": "[resourceId('Microsoft.Automation/automationAccounts', parameters('automationAccountName'))]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[subscriptionResourceId('Microsoft.Resources/resourceGroups', parameters('resourceGroupName'))]"
+      ]
+    },
+    {
+      "condition": "[variables('hasStorageAccounts')]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('AvdAlerts-RoleAssign-LAW-{0}', variables('deploymentSuffix'))]",
+      "subscriptionId": "[variables('lawSubscriptionId')]",
+      "resourceGroup": "[variables('lawResourceGroup')]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "principalId": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', format('AvdAlerts-AutomationAccount-{0}', variables('deploymentSuffix'))), '2025-04-01').outputs.principalId.value]"
+          },
+          "roleDefinitionId": {
+            "value": "92aaf0da-9dab-42b6-94a3-d43ce8d16293"
+          },
+          "resourceGroupName": {
+            "value": "[variables('lawResourceGroup')]"
+          },
+          "nameSuffix": {
+            "value": "[variables('automationAccountName')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.39.26.7824",
+              "templateHash": "16703140947059556488"
+            }
+          },
+          "parameters": {
+            "principalId": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Principal ID (object ID) of the managed identity."
+              }
+            },
+            "roleDefinitionId": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. GUID of the built-in role definition to assign."
+              }
+            },
+            "resourceGroupName": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Name of the resource group (used as part of the role assignment name to ensure uniqueness)."
+              }
+            },
+            "nameSuffix": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Additional suffix to disambiguate the role assignment when the same role is assigned multiple times in different resource groups."
+              }
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "name": "[guid(resourceGroup().id, parameters('principalId'), parameters('roleDefinitionId'), parameters('resourceGroupName'), parameters('nameSuffix'))]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', parameters('roleDefinitionId'))]",
+                "principalId": "[parameters('principalId')]",
+                "principalType": "ServicePrincipal"
+              }
+            }
+          ]
+        }
+      },
+      "dependsOn": [
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', format('AvdAlerts-AutomationAccount-{0}', variables('deploymentSuffix')))]"
+      ]
+    },
+    {
+      "copy": {
+        "name": "roleAssignStorage",
+        "count": "[length(variables('storageRgPairs'))]"
+      },
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('AvdAlerts-RoleAssign-Stor{0}-{1}', copyIndex(), variables('deploymentSuffix'))]",
+      "subscriptionId": "[split(variables('storageRgPairs')[copyIndex()], ',')[0]]",
+      "resourceGroup": "[split(variables('storageRgPairs')[copyIndex()], ',')[1]]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "principalId": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', format('AvdAlerts-AutomationAccount-{0}', variables('deploymentSuffix'))), '2025-04-01').outputs.principalId.value]"
+          },
+          "roleDefinitionId": {
+            "value": "17d1049b-9a84-46fb-8f53-869881c3d3ab"
+          },
+          "resourceGroupName": {
+            "value": "[split(variables('storageRgPairs')[copyIndex()], ',')[1]]"
+          },
+          "nameSuffix": {
+            "value": "[format('{0}-stor{1}', variables('automationAccountName'), copyIndex())]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.39.26.7824",
+              "templateHash": "16703140947059556488"
+            }
+          },
+          "parameters": {
+            "principalId": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Principal ID (object ID) of the managed identity."
+              }
+            },
+            "roleDefinitionId": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. GUID of the built-in role definition to assign."
+              }
+            },
+            "resourceGroupName": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Name of the resource group (used as part of the role assignment name to ensure uniqueness)."
+              }
+            },
+            "nameSuffix": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Additional suffix to disambiguate the role assignment when the same role is assigned multiple times in different resource groups."
+              }
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "name": "[guid(resourceGroup().id, parameters('principalId'), parameters('roleDefinitionId'), parameters('resourceGroupName'), parameters('nameSuffix'))]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', parameters('roleDefinitionId'))]",
+                "principalId": "[parameters('principalId')]",
+                "principalType": "ServicePrincipal"
+              }
+            }
+          ]
+        }
+      },
+      "dependsOn": [
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', format('AvdAlerts-AutomationAccount-{0}', variables('deploymentSuffix')))]"
+      ]
+    },
+    {
+      "copy": {
+        "name": "hostPoolLogAlerts",
+        "count": "[length(variables('hostPoolInfoDeduped'))]"
+      },
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('AvdAlerts-HP-{0}-{1}', last(split(variables('hostPoolInfoDeduped')[copyIndex()].hostPoolResourceId, '/')), variables('deploymentSuffix'))]",
+      "resourceGroup": "[parameters('resourceGroupName')]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "hostPoolName": {
+            "value": "[last(split(variables('hostPoolInfoDeduped')[copyIndex()].hostPoolResourceId, '/'))]"
+          },
+          "logAnalyticsWorkspaceResourceId": {
+            "value": "[parameters('logAnalyticsWorkspaceResourceId')]"
+          },
+          "actionGroupResourceId": {
+            "value": "[parameters('actionGroupResourceId')]"
+          },
+          "alertNamePrefix": {
+            "value": "[parameters('alertNamePrefix')]"
+          },
+          "autoResolveAlert": {
+            "value": "[parameters('autoResolveAlert')]"
+          },
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "enableCapacityAlerts": {
+            "value": "[parameters('enableCapacityAlerts')]"
+          },
+          "enableAvailabilityAlerts": {
+            "value": "[parameters('enableAvailabilityAlerts')]"
+          },
+          "enableConnectionAlerts": {
+            "value": "[parameters('enableConnectionAlerts')]"
+          },
+          "enableLocalDiskAlerts": {
+            "value": "[parameters('enableLocalDiskAlerts')]"
+          },
+          "enableFslogixAlerts": {
+            "value": "[parameters('enableFslogixAlerts')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.39.26.7824",
+              "templateHash": "11460574009713452450"
+            }
+          },
+          "parameters": {
+            "hostPoolName": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Name of the host pool (not the resource ID)."
+              }
+            },
+            "logAnalyticsWorkspaceResourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Resource ID of the Log Analytics Workspace."
+              }
+            },
+            "actionGroupResourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Resource ID of the Action Group for notifications."
+              }
+            },
+            "alertNamePrefix": {
+              "type": "string",
+              "defaultValue": "AVD",
+              "metadata": {
+                "description": "Optional. Prefix prepended to all alert names."
+              }
+            },
+            "autoResolveAlert": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Whether alert rules auto-resolve when the condition clears."
+              }
+            },
+            "location": {
+              "type": "string",
+              "metadata": {
+                "description": "Optional. Azure region for the alert rule resources."
+              }
+            },
+            "enableCapacityAlerts": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. When false, host pool capacity alert rules (50%, 85%, 95%) are not deployed."
+              }
+            },
+            "enableAvailabilityAlerts": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. When false, host availability and VM health alert rules are not deployed."
+              }
+            },
+            "enableConnectionAlerts": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. When false, user connection failure and disconnected session alert rules are not deployed."
+              }
+            },
+            "enableLocalDiskAlerts": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. When false, session host local disk free-space alert rules are not deployed."
+              }
+            },
+            "enableFslogixAlerts": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. When false, FSLogix profile alert rules are not deployed."
+              }
+            }
+          },
+          "variables": {
+            "descriptionHeader": "FederalAVD - Automated Alert\n",
+            "actions": {
+              "actionGroups": [
+                "[parameters('actionGroupResourceId')]"
+              ]
+            }
+          },
+          "resources": [
+            {
+              "condition": "[parameters('enableCapacityAlerts')]",
+              "type": "Microsoft.Insights/scheduledQueryRules",
+              "apiVersion": "2022-06-15",
+              "name": "[format('{0}-HP-Cap-50Prcnt-{1}', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "displayName": "[format('{0} - Host Pool Capacity 50% ({1})', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+                "description": "[format('{0}Host pool is at 50-84% capacity. Review scaling plan and available session hosts for {1}.', variables('descriptionHeader'), parameters('hostPoolName'))]",
+                "severity": 3,
+                "enabled": true,
+                "evaluationFrequency": "PT5M",
+                "windowSize": "PT15M",
+                "overrideQueryTimeRange": "P2D",
+                "scopes": [
+                  "[parameters('logAnalyticsWorkspaceResourceId')]"
+                ],
+                "autoMitigate": "[parameters('autoResolveAlert')]",
+                "criteria": {
+                  "allOf": [
+                    {
+                      "query": "WVDAgentHealthStatus\r\n| where TimeGenerated > ago(15m)\r\n| where _ResourceId contains '${hostPoolName}'\r\n| summarize arg_max(TimeGenerated, ActiveSessions, MaxSessions, AllowNewSessions, Status, _ResourceId) by SessionHostName\r\n| summarize\r\n    TotalActive   = sum(ActiveSessions),\r\n    TotalCapacity = sum(iff(AllowNewSessions and Status == 'Available', MaxSessions, 0)),\r\n    ResourceId    = any(_ResourceId)\r\n| extend LoadPct = iff(TotalCapacity > 0, round(100.0 * TotalActive / TotalCapacity, 0), 0)\r\n| where TotalCapacity > 0 and LoadPct >= 50 and LoadPct < 85\r\n",
+                      "timeAggregation": "Count",
+                      "dimensions": [
+                        {
+                          "name": "TotalActive",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "TotalCapacity",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "LoadPct",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        }
+                      ],
+                      "resourceIdColumn": "ResourceId",
+                      "operator": "GreaterThanOrEqual",
+                      "threshold": 1,
+                      "failingPeriods": {
+                        "numberOfEvaluationPeriods": 1,
+                        "minFailingPeriodsToAlert": 1
+                      }
+                    }
+                  ]
+                },
+                "actions": "[variables('actions')]"
+              }
+            },
+            {
+              "condition": "[parameters('enableCapacityAlerts')]",
+              "type": "Microsoft.Insights/scheduledQueryRules",
+              "apiVersion": "2022-06-15",
+              "name": "[format('{0}-HP-Cap-85Prcnt-{1}', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "displayName": "[format('{0} - Host Pool Capacity 85% ({1})', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+                "description": "[format('{0}Host pool is at 85-94% capacity. Review scaling plan and consider adding session hosts for {1}.', variables('descriptionHeader'), parameters('hostPoolName'))]",
+                "severity": 2,
+                "enabled": true,
+                "evaluationFrequency": "PT5M",
+                "windowSize": "PT15M",
+                "overrideQueryTimeRange": "P2D",
+                "scopes": [
+                  "[parameters('logAnalyticsWorkspaceResourceId')]"
+                ],
+                "autoMitigate": "[parameters('autoResolveAlert')]",
+                "criteria": {
+                  "allOf": [
+                    {
+                      "query": "WVDAgentHealthStatus\r\n| where TimeGenerated > ago(15m)\r\n| where _ResourceId contains '${hostPoolName}'\r\n| summarize arg_max(TimeGenerated, ActiveSessions, MaxSessions, AllowNewSessions, Status, _ResourceId) by SessionHostName\r\n| summarize\r\n    TotalActive   = sum(ActiveSessions),\r\n    TotalCapacity = sum(iff(AllowNewSessions and Status == 'Available', MaxSessions, 0)),\r\n    ResourceId    = any(_ResourceId)\r\n| extend LoadPct = iff(TotalCapacity > 0, round(100.0 * TotalActive / TotalCapacity, 0), 0)\r\n| where TotalCapacity > 0 and LoadPct >= 85 and LoadPct < 95\r\n",
+                      "timeAggregation": "Count",
+                      "dimensions": [
+                        {
+                          "name": "TotalActive",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "TotalCapacity",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "LoadPct",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        }
+                      ],
+                      "resourceIdColumn": "ResourceId",
+                      "operator": "GreaterThanOrEqual",
+                      "threshold": 1,
+                      "failingPeriods": {
+                        "numberOfEvaluationPeriods": 1,
+                        "minFailingPeriodsToAlert": 1
+                      }
+                    }
+                  ]
+                },
+                "actions": "[variables('actions')]"
+              }
+            },
+            {
+              "condition": "[parameters('enableCapacityAlerts')]",
+              "type": "Microsoft.Insights/scheduledQueryRules",
+              "apiVersion": "2022-06-15",
+              "name": "[format('{0}-HP-Cap-95Prcnt-{1}', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "displayName": "[format('{0} - Host Pool Capacity 95% ({1})', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+                "description": "[format('{0}Host pool is at or above 95% capacity. Immediate action required to add session hosts for {1}.', variables('descriptionHeader'), parameters('hostPoolName'))]",
+                "severity": 1,
+                "enabled": true,
+                "evaluationFrequency": "PT5M",
+                "windowSize": "PT15M",
+                "overrideQueryTimeRange": "P2D",
+                "scopes": [
+                  "[parameters('logAnalyticsWorkspaceResourceId')]"
+                ],
+                "autoMitigate": "[parameters('autoResolveAlert')]",
+                "criteria": {
+                  "allOf": [
+                    {
+                      "query": "WVDAgentHealthStatus\r\n| where TimeGenerated > ago(15m)\r\n| where _ResourceId contains '${hostPoolName}'\r\n| summarize arg_max(TimeGenerated, ActiveSessions, MaxSessions, AllowNewSessions, Status, _ResourceId) by SessionHostName\r\n| summarize\r\n    TotalActive   = sum(ActiveSessions),\r\n    TotalCapacity = sum(iff(AllowNewSessions and Status == 'Available', MaxSessions, 0)),\r\n    ResourceId    = any(_ResourceId)\r\n| extend LoadPct = iff(TotalCapacity > 0, round(100.0 * TotalActive / TotalCapacity, 0), 0)\r\n| where TotalCapacity > 0 and LoadPct >= 95\r\n",
+                      "timeAggregation": "Count",
+                      "dimensions": [
+                        {
+                          "name": "TotalActive",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "TotalCapacity",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "LoadPct",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        }
+                      ],
+                      "resourceIdColumn": "ResourceId",
+                      "operator": "GreaterThanOrEqual",
+                      "threshold": 1,
+                      "failingPeriods": {
+                        "numberOfEvaluationPeriods": 1,
+                        "minFailingPeriodsToAlert": 1
+                      }
+                    }
+                  ]
+                },
+                "actions": "[variables('actions')]"
+              }
+            },
+            {
+              "condition": "[parameters('enableAvailabilityAlerts')]",
+              "type": "Microsoft.Insights/scheduledQueryRules",
+              "apiVersion": "2022-06-15",
+              "name": "[format('{0}-HP-VM-PersnlAssigndUnhlthy-{1}', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "displayName": "[format('{0} - Personal Pool Session Host Unhealthy ({1})', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+                "description": "[format('{0}A session host in the personal host pool {1} is not in an Available state. Investigate the affected VM and its health check results.', variables('descriptionHeader'), parameters('hostPoolName'))]",
+                "severity": 1,
+                "enabled": true,
+                "evaluationFrequency": "PT5M",
+                "windowSize": "PT15M",
+                "overrideQueryTimeRange": "P2D",
+                "scopes": [
+                  "[parameters('logAnalyticsWorkspaceResourceId')]"
+                ],
+                "autoMitigate": "[parameters('autoResolveAlert')]",
+                "criteria": {
+                  "allOf": [
+                    {
+                      "query": "WVDAgentHealthStatus\r\n| where TimeGenerated > ago(15m)\r\n| where _ResourceId contains '${hostPoolName}'\r\n| summarize arg_max(TimeGenerated, Status, _ResourceId) by SessionHostName\r\n| where Status != 'Available' and Status != 'Shutdown'\r\n| project SessionHostName, Status, ResourceId = _ResourceId\r\n",
+                      "timeAggregation": "Count",
+                      "dimensions": [
+                        {
+                          "name": "SessionHostName",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "Status",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        }
+                      ],
+                      "resourceIdColumn": "ResourceId",
+                      "operator": "GreaterThanOrEqual",
+                      "threshold": 1,
+                      "failingPeriods": {
+                        "numberOfEvaluationPeriods": 1,
+                        "minFailingPeriodsToAlert": 1
+                      }
+                    }
+                  ]
+                },
+                "actions": "[variables('actions')]"
+              }
+            },
+            {
+              "condition": "[parameters('enableAvailabilityAlerts')]",
+              "type": "Microsoft.Insights/scheduledQueryRules",
+              "apiVersion": "2022-06-15",
+              "name": "[format('{0}-HP-NoResAvail-{1}', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "displayName": "[format('{0} - No Resources Available ({1})', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+                "description": "[format('{0}Catastrophic: no healthy session hosts available for new connections in {1}. Diagnose host pool dependencies immediately.', variables('descriptionHeader'), parameters('hostPoolName'))]",
+                "severity": 1,
+                "enabled": true,
+                "evaluationFrequency": "PT15M",
+                "windowSize": "PT15M",
+                "overrideQueryTimeRange": "P2D",
+                "scopes": [
+                  "[parameters('logAnalyticsWorkspaceResourceId')]"
+                ],
+                "autoMitigate": "[parameters('autoResolveAlert')]",
+                "criteria": {
+                  "allOf": [
+                    {
+                      "query": "WVDConnections\r\n| where TimeGenerated > ago(15m)\r\n| where _ResourceId contains '${hostPoolName}'\r\n| project-away TenantId, SourceSystem\r\n| summarize arg_max(TimeGenerated, *), StartTime = min(iff(State == 'Started', TimeGenerated, datetime(null))), ConnectTime = min(iff(State == 'Connected', TimeGenerated, datetime(null))) by CorrelationId\r\n| join kind=leftouter (\r\n    WVDErrors\r\n    | summarize Errors=make_list(pack('Code', Code, 'CodeSymbolic', CodeSymbolic, 'Time', TimeGenerated, 'Message', Message, 'ServiceError', ServiceError, 'Source', Source)) by CorrelationId\r\n) on CorrelationId\r\n| join kind=leftouter (\r\n    WVDCheckpoints\r\n    | summarize Checkpoints=make_list(pack('Time', TimeGenerated, 'Name', Name, 'Parameters', Parameters, 'Source', Source)) by CorrelationId\r\n    | mv-apply Checkpoints on (\r\n        order by todatetime(Checkpoints['Time']) asc\r\n        | summarize Checkpoints=make_list(Checkpoints)\r\n    )\r\n) on CorrelationId\r\n| project-away CorrelationId1, CorrelationId2\r\n| order by TimeGenerated desc\r\n| where Errors[0].CodeSymbolic == \"ConnectionFailedNoHealthyRdshAvailable\"\r\n",
+                      "timeAggregation": "Count",
+                      "dimensions": [
+                        {
+                          "name": "UserName",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "SessionHostName",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        }
+                      ],
+                      "operator": "GreaterThanOrEqual",
+                      "threshold": 1,
+                      "failingPeriods": {
+                        "numberOfEvaluationPeriods": 1,
+                        "minFailingPeriodsToAlert": 1
+                      }
+                    }
+                  ]
+                },
+                "actions": "[variables('actions')]"
+              }
+            },
+            {
+              "condition": "[parameters('enableAvailabilityAlerts')]",
+              "type": "Microsoft.Insights/scheduledQueryRules",
+              "apiVersion": "2022-06-15",
+              "name": "[format('{0}-HP-VM-HlthChkFailure-{1}', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "displayName": "[format('{0} - VM Health Check Failure ({1})', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+                "description": "[format('{0}A session host in {1} is available but a dependent resource (domain, FSLogix, SxS stack, URL check) is in a failed state.', variables('descriptionHeader'), parameters('hostPoolName'))]",
+                "severity": 1,
+                "enabled": true,
+                "evaluationFrequency": "PT15M",
+                "windowSize": "PT15M",
+                "overrideQueryTimeRange": "P2D",
+                "scopes": [
+                  "[parameters('logAnalyticsWorkspaceResourceId')]"
+                ],
+                "autoMitigate": "[parameters('autoResolveAlert')]",
+                "criteria": {
+                  "allOf": [
+                    {
+                      "query": "let MapToDesc = (idx: long) {\r\n    case(idx == 0, \"DomainJoin\",\r\n    idx == 1, \"DomainTrust\",\r\n    idx == 2, \"FSLogix\",\r\n    idx == 3, \"SxSStack\",\r\n    idx == 4, \"URLCheck\",\r\n    idx == 5, \"GenevaAgent\",\r\n    idx == 6, \"DomainReachable\",\r\n    idx == 7, \"WebRTCRedirector\",\r\n    idx == 8, \"SxSStackEncryption\",\r\n    idx == 9, \"IMDSReachable\",\r\n    idx == 10, \"MSIXPackageStaging\",\r\n    \"InvalidIndex\")\r\n};\r\nWVDAgentHealthStatus\r\n| where TimeGenerated > ago(10m)\r\n| where Status != 'Available'\r\n| where AllowNewSessions == true\r\n| extend CheckFailed = parse_json(SessionHostHealthCheckResult)\r\n| mv-expand CheckFailed\r\n| where CheckFailed.AdditionalFailureDetails.ErrorCode != 0\r\n| extend HealthCheckName = tolong(CheckFailed.HealthCheckName)\r\n| extend HealthCheckResult = tolong(CheckFailed.HealthCheckResult)\r\n| extend HealthCheckDesc = MapToDesc(HealthCheckName)\r\n| where HealthCheckDesc != \"InvalidIndex\"\r\n| where _ResourceId contains '${hostPoolName}'\r\n| parse _ResourceId with \"/subscriptions/\" subscription \"/resourcegroups/\" HostPoolResourceGroup \"/providers/microsoft.desktopvirtualization/hostpools/\" HostPool\r\n| parse SessionHostResourceId with \"/subscriptions/\" HostSubscription \"/resourceGroups/\" SessionHostRG \"/providers/Microsoft.Compute/virtualMachines/\" SessionHostName\r\n",
+                      "timeAggregation": "Count",
+                      "dimensions": [
+                        {
+                          "name": "SessionHostName",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "HealthCheckDesc",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "HostPool",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "SessionHostRG",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        }
+                      ],
+                      "operator": "GreaterThanOrEqual",
+                      "threshold": 1,
+                      "failingPeriods": {
+                        "numberOfEvaluationPeriods": 1,
+                        "minFailingPeriodsToAlert": 1
+                      }
+                    }
+                  ]
+                },
+                "actions": "[variables('actions')]"
+              }
+            },
+            {
+              "condition": "[parameters('enableConnectionAlerts')]",
+              "type": "Microsoft.Insights/scheduledQueryRules",
+              "apiVersion": "2022-06-15",
+              "name": "[format('{0}-HP-Usr-ConnctnFailed-{1}', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "displayName": "[format('{0} - User Connection Failed ({1})', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+                "description": "[format('{0}A user failed to connect to a session host in {1}. If frequent, investigate network latency (>150ms) and session host availability.', variables('descriptionHeader'), parameters('hostPoolName'))]",
+                "severity": 3,
+                "enabled": true,
+                "evaluationFrequency": "PT15M",
+                "windowSize": "PT15M",
+                "overrideQueryTimeRange": "P2D",
+                "scopes": [
+                  "[parameters('logAnalyticsWorkspaceResourceId')]"
+                ],
+                "autoMitigate": "[parameters('autoResolveAlert')]",
+                "criteria": {
+                  "allOf": [
+                    {
+                      "query": "WVDConnections\r\n| project-away TenantId, SourceSystem\r\n| summarize arg_max(TimeGenerated, *), StartTime = min(iff(State == 'Started', TimeGenerated, datetime(null))), ConnectTime = min(iff(State == 'Connected', TimeGenerated, datetime(null))) by CorrelationId\r\n| join kind=leftouter (\r\n    WVDErrors\r\n    | summarize Errors=make_list(pack('Code', Code, 'CodeSymbolic', CodeSymbolic, 'Time', TimeGenerated, 'Message', Message, 'ServiceError', ServiceError, 'Source', Source)) by CorrelationId\r\n) on CorrelationId\r\n| join kind=leftouter (\r\n    WVDCheckpoints\r\n    | summarize Checkpoints=make_list(pack('Time', TimeGenerated, 'Name', Name, 'Parameters', Parameters, 'Source', Source)) by CorrelationId\r\n    | mv-apply Checkpoints on (\r\n        order by todatetime(Checkpoints['Time']) asc\r\n        | summarize Checkpoints=make_list(Checkpoints)\r\n    )\r\n) on CorrelationId\r\n| project-away CorrelationId1, CorrelationId2\r\n| order by TimeGenerated desc\r\n| where TimeGenerated > ago(15m)\r\n| extend ResourceGroup=tostring(split(_ResourceId, '/')[4])\r\n| extend HostPool=tostring(split(_ResourceId, '/')[8])\r\n| where HostPool =~ '${hostPoolName}'\r\n| where isnotempty(Errors)\r\n| extend ErrorShort=tostring(Errors[0].CodeSymbolic)\r\n| extend ErrorMessage=tostring(Errors[0].Message)\r\n| project TimeGenerated, HostPool, ResourceGroup, UserName, ClientOS, ClientVersion, ClientSideIPAddress, ConnectionType, ErrorShort, ErrorMessage\r\n",
+                      "timeAggregation": "Count",
+                      "dimensions": [
+                        {
+                          "name": "HostPool",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "UserName",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "ErrorShort",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        }
+                      ],
+                      "operator": "GreaterThanOrEqual",
+                      "threshold": 1,
+                      "failingPeriods": {
+                        "numberOfEvaluationPeriods": 1,
+                        "minFailingPeriodsToAlert": 1
+                      }
+                    }
+                  ]
+                },
+                "actions": "[variables('actions')]"
+              }
+            },
+            {
+              "condition": "[parameters('enableConnectionAlerts')]",
+              "type": "Microsoft.Insights/scheduledQueryRules",
+              "apiVersion": "2022-06-15",
+              "name": "[format('{0}-HP-DiscUser24Hrs-{1}', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "displayName": "[format('{0} - Disconnected User Over 24 Hours ({1})', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+                "description": "[format('{0}A user in {1} has a disconnected session lasting more than 24 hours. Verify Remote Desktop session limit policies are applied. This could affect scaling plans.', variables('descriptionHeader'), parameters('hostPoolName'))]",
+                "severity": 2,
+                "enabled": true,
+                "evaluationFrequency": "PT1H",
+                "windowSize": "PT1H",
+                "overrideQueryTimeRange": "P2D",
+                "scopes": [
+                  "[parameters('logAnalyticsWorkspaceResourceId')]"
+                ],
+                "autoMitigate": "[parameters('autoResolveAlert')]",
+                "criteria": {
+                  "allOf": [
+                    {
+                      "query": "WVDConnections\r\n| where TimeGenerated > ago(24h)\r\n| where State == \"Connected\"\r\n| where _ResourceId contains '${hostPoolName}'\r\n| project CorrelationId, UserName, ConnectionType, StartTime=TimeGenerated, SessionHostName\r\n| join (\r\n    WVDConnections\r\n    | where State == \"Completed\"\r\n    | project EndTime=TimeGenerated, CorrelationId\r\n) on CorrelationId\r\n| project Duration = EndTime - StartTime, ConnectionType, UserName, SessionHostName\r\n| where Duration >= timespan(24:00:00)\r\n| sort by Duration desc\r\n",
+                      "timeAggregation": "Count",
+                      "dimensions": [
+                        {
+                          "name": "UserName",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "SessionHostName",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        }
+                      ],
+                      "operator": "GreaterThanOrEqual",
+                      "threshold": 1,
+                      "failingPeriods": {
+                        "numberOfEvaluationPeriods": 1,
+                        "minFailingPeriodsToAlert": 1
+                      }
+                    }
+                  ]
+                },
+                "actions": "[variables('actions')]"
+              }
+            },
+            {
+              "condition": "[parameters('enableConnectionAlerts')]",
+              "type": "Microsoft.Insights/scheduledQueryRules",
+              "apiVersion": "2022-06-15",
+              "name": "[format('{0}-HP-DiscUser72Hrs-{1}', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "displayName": "[format('{0} - Disconnected User Over 72 Hours ({1})', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+                "description": "[format('{0}A user in {1} has a disconnected session lasting more than 72 hours. This likely indicates stale sessions blocking scaling automation. Verify session limit policies.', variables('descriptionHeader'), parameters('hostPoolName'))]",
+                "severity": 1,
+                "enabled": true,
+                "evaluationFrequency": "PT1H",
+                "windowSize": "PT1H",
+                "overrideQueryTimeRange": "P2D",
+                "scopes": [
+                  "[parameters('logAnalyticsWorkspaceResourceId')]"
+                ],
+                "autoMitigate": "[parameters('autoResolveAlert')]",
+                "criteria": {
+                  "allOf": [
+                    {
+                      "query": "WVDConnections\r\n| where TimeGenerated > ago(24h)\r\n| where State == \"Connected\"\r\n| where _ResourceId contains '${hostPoolName}'\r\n| project CorrelationId, UserName, ConnectionType, StartTime=TimeGenerated, SessionHostName\r\n| join (\r\n    WVDConnections\r\n    | where State == \"Completed\"\r\n    | project EndTime=TimeGenerated, CorrelationId\r\n) on CorrelationId\r\n| project Duration = EndTime - StartTime, ConnectionType, UserName, SessionHostName\r\n| where Duration >= timespan(72:00:00)\r\n| sort by Duration desc\r\n",
+                      "timeAggregation": "Count",
+                      "dimensions": [
+                        {
+                          "name": "UserName",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "SessionHostName",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        }
+                      ],
+                      "operator": "GreaterThanOrEqual",
+                      "threshold": 1,
+                      "failingPeriods": {
+                        "numberOfEvaluationPeriods": 1,
+                        "minFailingPeriodsToAlert": 1
+                      }
+                    }
+                  ]
+                },
+                "actions": "[variables('actions')]"
+              }
+            },
+            {
+              "condition": "[parameters('enableLocalDiskAlerts')]",
+              "type": "Microsoft.Insights/scheduledQueryRules",
+              "apiVersion": "2022-06-15",
+              "name": "[format('{0}-HP-VM-LocDskFree10Prcnt-{1}', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "displayName": "[format('{0} - VM Local Disk Free <= 10% ({1})', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+                "description": "[format('{0}A session host in {1} has 10% or less free space on the C: drive. Review local profiles, temp files, and application logs consuming disk space.', variables('descriptionHeader'), parameters('hostPoolName'))]",
+                "severity": 2,
+                "enabled": true,
+                "evaluationFrequency": "PT15M",
+                "windowSize": "PT15M",
+                "overrideQueryTimeRange": "P2D",
+                "scopes": [
+                  "[parameters('logAnalyticsWorkspaceResourceId')]"
+                ],
+                "autoMitigate": "[parameters('autoResolveAlert')]",
+                "criteria": {
+                  "allOf": [
+                    {
+                      "query": "Perf\r\n| where TimeGenerated > ago(15m)\r\n| where ObjectName == \"LogicalDisk\" and CounterName == \"% Free Space\"\r\n| where InstanceName !contains \"D:\" and InstanceName !contains \"_Total\"\r\n| where CounterValue <= 10.00\r\n| parse _ResourceId with \"/subscriptions/\" subscription \"/resourcegroups/\" ResourceGroup \"/providers/microsoft.compute/virtualmachines/\" ComputerName\r\n| summarize arg_max(TimeGenerated, *) by ComputerName\r\n| extend ComputerName=tolower(ComputerName)\r\n| project ComputerName, CounterValue, subscription, ResourceGroup, TimeGenerated\r\n| join kind=leftouter (\r\n    WVDAgentHealthStatus\r\n    | where TimeGenerated > ago(15m)\r\n    | where _ResourceId contains '${hostPoolName}'\r\n    | parse _ResourceId with \"/subscriptions/\" subscriptionAgentHealth \"/resourcegroups/\" ResourceGroupAgentHealth \"/providers/microsoft.desktopvirtualization/hostpools/\" HostPool\r\n    | parse SessionHostResourceId with \"/subscriptions/\" VMsubscription \"/resourceGroups/\" VMresourceGroup \"/providers/Microsoft.Compute/virtualMachines/\" ComputerName\r\n    | extend ComputerName=tolower(ComputerName)\r\n    | summarize arg_max(TimeGenerated, *) by ComputerName\r\n    | project VMresourceGroup, ComputerName, HostPool, _ResourceId\r\n) on ComputerName\r\n| where ComputerName1 contains ComputerName\r\n",
+                      "timeAggregation": "Count",
+                      "dimensions": [
+                        {
+                          "name": "ComputerName",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "VMresourceGroup",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "HostPool",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        }
+                      ],
+                      "resourceIdColumn": "_ResourceId",
+                      "operator": "GreaterThanOrEqual",
+                      "threshold": 1,
+                      "failingPeriods": {
+                        "numberOfEvaluationPeriods": 1,
+                        "minFailingPeriodsToAlert": 1
+                      }
+                    }
+                  ]
+                },
+                "actions": "[variables('actions')]"
+              }
+            },
+            {
+              "condition": "[parameters('enableLocalDiskAlerts')]",
+              "type": "Microsoft.Insights/scheduledQueryRules",
+              "apiVersion": "2022-06-15",
+              "name": "[format('{0}-HP-VM-LocDskFree5Prcnt-{1}', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "displayName": "[format('{0} - VM Local Disk Free <= 5% ({1})', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+                "description": "[format('{0}CRITICAL: A session host in {1} has 5% or less free space on the C: drive. Immediate action required to free disk space.', variables('descriptionHeader'), parameters('hostPoolName'))]",
+                "severity": 1,
+                "enabled": true,
+                "evaluationFrequency": "PT15M",
+                "windowSize": "PT15M",
+                "overrideQueryTimeRange": "P2D",
+                "scopes": [
+                  "[parameters('logAnalyticsWorkspaceResourceId')]"
+                ],
+                "autoMitigate": "[parameters('autoResolveAlert')]",
+                "criteria": {
+                  "allOf": [
+                    {
+                      "query": "Perf\r\n| where TimeGenerated > ago(15m)\r\n| where ObjectName == \"LogicalDisk\" and CounterName == \"% Free Space\"\r\n| where InstanceName !contains \"D:\" and InstanceName !contains \"_Total\"\r\n| where CounterValue <= 5.00\r\n| parse _ResourceId with \"/subscriptions/\" subscription \"/resourcegroups/\" ResourceGroup \"/providers/microsoft.compute/virtualmachines/\" ComputerName\r\n| summarize arg_max(TimeGenerated, *) by ComputerName\r\n| extend ComputerName=tolower(ComputerName)\r\n| project ComputerName, CounterValue, subscription, ResourceGroup, TimeGenerated\r\n| join kind=leftouter (\r\n    WVDAgentHealthStatus\r\n    | where TimeGenerated > ago(15m)\r\n    | where _ResourceId contains '${hostPoolName}'\r\n    | parse _ResourceId with \"/subscriptions/\" subscriptionAgentHealth \"/resourcegroups/\" ResourceGroupAgentHealth \"/providers/microsoft.desktopvirtualization/hostpools/\" HostPool\r\n    | parse SessionHostResourceId with \"/subscriptions/\" VMsubscription \"/resourceGroups/\" VMresourceGroup \"/providers/Microsoft.Compute/virtualMachines/\" ComputerName\r\n    | extend ComputerName=tolower(ComputerName)\r\n    | summarize arg_max(TimeGenerated, *) by ComputerName\r\n    | project VMresourceGroup, ComputerName, HostPool, _ResourceId\r\n) on ComputerName\r\n| where ComputerName1 contains ComputerName\r\n",
+                      "timeAggregation": "Count",
+                      "dimensions": [
+                        {
+                          "name": "ComputerName",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "VMresourceGroup",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "HostPool",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        }
+                      ],
+                      "resourceIdColumn": "_ResourceId",
+                      "operator": "GreaterThanOrEqual",
+                      "threshold": 1,
+                      "failingPeriods": {
+                        "numberOfEvaluationPeriods": 1,
+                        "minFailingPeriodsToAlert": 1
+                      }
+                    }
+                  ]
+                },
+                "actions": "[variables('actions')]"
+              }
+            },
+            {
+              "condition": "[parameters('enableFslogixAlerts')]",
+              "type": "Microsoft.Insights/scheduledQueryRules",
+              "apiVersion": "2022-06-15",
+              "name": "[format('{0}-HP-VM-FSLgxProf5PrcntFree-{1}', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "displayName": "[format('{0} - FSLogix Profile < 5% Free Space ({1})', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+                "description": "[format('{0}FSLogix Event ID 34: a user profile VHD in {1} has less than 5% free space. Expand the VHD or clean up profile data.', variables('descriptionHeader'), parameters('hostPoolName'))]",
+                "severity": 2,
+                "enabled": true,
+                "evaluationFrequency": "PT5M",
+                "windowSize": "PT5M",
+                "scopes": [
+                  "[parameters('logAnalyticsWorkspaceResourceId')]"
+                ],
+                "autoMitigate": "[parameters('autoResolveAlert')]",
+                "criteria": {
+                  "allOf": [
+                    {
+                      "query": "Event\r\n| where EventLog == \"Microsoft-FSLogix-Apps/Admin\"\r\n| where EventLevelName == \"Warning\"\r\n| where EventID == 34\r\n| parse _ResourceId with \"/subscriptions/\" subscription \"/resourcegroups/\" ResourceGroup \"/providers/microsoft.compute/virtualmachines/\" ComputerName\r\n| extend ComputerName=tolower(ComputerName)\r\n| project ComputerName, RenderedDescription, subscription, ResourceGroup, TimeGenerated\r\n| join kind=leftouter (\r\n    WVDAgentHealthStatus\r\n    | where _ResourceId contains '${hostPoolName}'\r\n    | parse _ResourceId with \"/subscriptions/\" subscriptionAgentHealth \"/resourcegroups/\" ResourceGroupAgentHealth \"/providers/microsoft.desktopvirtualization/hostpools/\" HostPool\r\n    | parse SessionHostResourceId with \"/subscriptions/\" VMsubscription \"/resourceGroups/\" VMresourceGroup \"/providers/Microsoft.Compute/virtualMachines/\" ComputerName\r\n    | extend ComputerName=tolower(ComputerName)\r\n    | summarize arg_max(TimeGenerated, *) by ComputerName\r\n    | project VMresourceGroup, ComputerName, HostPool\r\n) on ComputerName\r\n",
+                      "timeAggregation": "Count",
+                      "dimensions": [
+                        {
+                          "name": "ComputerName",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "RenderedDescription",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "VMresourceGroup",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "HostPool",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        }
+                      ],
+                      "operator": "GreaterThanOrEqual",
+                      "threshold": 1,
+                      "failingPeriods": {
+                        "numberOfEvaluationPeriods": 1,
+                        "minFailingPeriodsToAlert": 1
+                      }
+                    }
+                  ]
+                },
+                "actions": "[variables('actions')]"
+              }
+            },
+            {
+              "condition": "[parameters('enableFslogixAlerts')]",
+              "type": "Microsoft.Insights/scheduledQueryRules",
+              "apiVersion": "2022-06-15",
+              "name": "[format('{0}-HP-VM-FSLgxProf2PrcntFree-{1}', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "displayName": "[format('{0} - FSLogix Profile < 2% Free Space ({1})', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+                "description": "[format('{0}CRITICAL: FSLogix Event ID 33 in {1}: a user profile VHD has less than 2% free space. The alert includes the affected user, profile container, and storage account. Expand the VHD or clean up profile data immediately.', variables('descriptionHeader'), parameters('hostPoolName'))]",
+                "severity": 1,
+                "enabled": true,
+                "evaluationFrequency": "PT5M",
+                "windowSize": "PT1H",
+                "overrideQueryTimeRange": "P2D",
+                "scopes": [
+                  "[parameters('logAnalyticsWorkspaceResourceId')]"
+                ],
+                "autoMitigate": "[parameters('autoResolveAlert')]",
+                "criteria": {
+                  "allOf": [
+                    {
+                      "query": "let fslogixErrors =\r\n    Event\r\n    | where Source == \"Microsoft-FSLogix-Apps\"\r\n    | where EventID == 33\r\n    | extend\r\n        StorageAccount = extract(@\"\\\\\\\\([^\\\\]+\\.file\\.core\\.(windows|usgovcloudapi)\\.net)\", 1, RenderedDescription),\r\n        ProfileRaw     = extract(@\"profilecontainers\\\\([^\\\\]+)\", 1, RenderedDescription)\r\n    | extend ProfileID = tostring(split(ProfileRaw, \"_\")[0])\r\n    | project EventTime = TimeGenerated, Computer, ProfileID, StorageAccount, EventID, RenderedDescription;\r\nfslogixErrors\r\n| join kind=inner (\r\n    WVDConnections\r\n    | where _ResourceId contains '${hostPoolName}'\r\n    | where State == \"Connected\"\r\n    | project ConnTime = TimeGenerated, UserName, SessionHostName, ResourceId = _ResourceId\r\n) on $left.Computer == $right.SessionHostName\r\n| extend TimeDiff = abs(datetime_diff('minute', EventTime, ConnTime))\r\n| where TimeDiff <= 30\r\n| summarize arg_min(TimeDiff, *) by EventTime, Computer\r\n| project\r\n    EventTime,\r\n    UserName,\r\n    ProfileID,\r\n    SessionHostName = Computer,\r\n    StorageAccount,\r\n    EventID,\r\n    RenderedDescription,\r\n    ResourceId\r\n| order by EventTime desc\r\n",
+                      "timeAggregation": "Count",
+                      "dimensions": [
+                        {
+                          "name": "UserName",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "ProfileID",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "SessionHostName",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "StorageAccount",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        }
+                      ],
+                      "resourceIdColumn": "ResourceId",
+                      "operator": "GreaterThanOrEqual",
+                      "threshold": 1,
+                      "failingPeriods": {
+                        "numberOfEvaluationPeriods": 1,
+                        "minFailingPeriodsToAlert": 1
+                      }
+                    }
+                  ]
+                },
+                "actions": "[variables('actions')]"
+              }
+            },
+            {
+              "condition": "[parameters('enableFslogixAlerts')]",
+              "type": "Microsoft.Insights/scheduledQueryRules",
+              "apiVersion": "2022-06-15",
+              "name": "[format('{0}-HP-VM-FSLgxProf-NetwrkIssue-{1}', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "displayName": "[format('{0} - FSLogix Profile Network Issue ({1})', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+                "description": "[format('{0}FSLogix Event ID 43: a session host in {1} cannot reach the FSLogix profile storage. Verify network connectivity between the session hosts and the storage account.', variables('descriptionHeader'), parameters('hostPoolName'))]",
+                "severity": 1,
+                "enabled": true,
+                "evaluationFrequency": "PT5M",
+                "windowSize": "P1D",
+                "scopes": [
+                  "[parameters('logAnalyticsWorkspaceResourceId')]"
+                ],
+                "autoMitigate": "[parameters('autoResolveAlert')]",
+                "criteria": {
+                  "allOf": [
+                    {
+                      "query": "Event\r\n| where EventLog == \"Microsoft-FSLogix-Apps/Admin\"\r\n| where EventLevelName == \"Error\"\r\n| where EventID == 43\r\n| parse _ResourceId with \"/subscriptions/\" subscription \"/resourcegroups/\" ResourceGroup \"/providers/microsoft.compute/virtualmachines/\" ComputerName\r\n| extend ComputerName=tolower(ComputerName)\r\n| project ComputerName, RenderedDescription, subscription, ResourceGroup, TimeGenerated\r\n| join kind=leftouter (\r\n    WVDAgentHealthStatus\r\n    | where _ResourceId contains '${hostPoolName}'\r\n    | parse _ResourceId with \"/subscriptions/\" subscriptionAgentHealth \"/resourcegroups/\" ResourceGroupAgentHealth \"/providers/microsoft.desktopvirtualization/hostpools/\" HostPool\r\n    | parse SessionHostResourceId with \"/subscriptions/\" VMsubscription \"/resourceGroups/\" VMresourceGroup \"/providers/Microsoft.Compute/virtualMachines/\" ComputerName\r\n    | extend ComputerName=tolower(ComputerName)\r\n    | summarize arg_max(TimeGenerated, *) by ComputerName\r\n    | project VMresourceGroup, ComputerName, HostPool\r\n) on ComputerName\r\n",
+                      "timeAggregation": "Count",
+                      "dimensions": [
+                        {
+                          "name": "ComputerName",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "RenderedDescription",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "VMresourceGroup",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "HostPool",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        }
+                      ],
+                      "resourceIdColumn": "_ResourceId",
+                      "operator": "GreaterThanOrEqual",
+                      "threshold": 1,
+                      "failingPeriods": {
+                        "numberOfEvaluationPeriods": 1,
+                        "minFailingPeriodsToAlert": 1
+                      }
+                    }
+                  ]
+                },
+                "actions": "[variables('actions')]"
+              }
+            },
+            {
+              "condition": "[parameters('enableFslogixAlerts')]",
+              "type": "Microsoft.Insights/scheduledQueryRules",
+              "apiVersion": "2022-06-15",
+              "name": "[format('{0}-HP-VM-FSLgxProf-FailAttVHD-{1}', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "displayName": "[format('{0} - FSLogix Profile Disk Failed to Attach ({1})', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+                "description": "[format('{0}FSLogix Event ID 52 or 40: the profile VHD failed to attach for a session host in {1}. Investigate FSLogix errors for details.', variables('descriptionHeader'), parameters('hostPoolName'))]",
+                "severity": 1,
+                "enabled": true,
+                "evaluationFrequency": "PT5M",
+                "windowSize": "P1D",
+                "scopes": [
+                  "[parameters('logAnalyticsWorkspaceResourceId')]"
+                ],
+                "autoMitigate": "[parameters('autoResolveAlert')]",
+                "criteria": {
+                  "allOf": [
+                    {
+                      "query": "Event\r\n| where EventLog == \"Microsoft-FSLogix-Apps/Admin\"\r\n| where EventLevelName == \"Error\"\r\n| where EventID == 52 or EventID == 40\r\n| parse _ResourceId with \"/subscriptions/\" subscription \"/resourcegroups/\" ResourceGroup \"/providers/microsoft.compute/virtualmachines/\" ComputerName\r\n| extend ComputerName=tolower(ComputerName)\r\n| project ComputerName, RenderedDescription, subscription, ResourceGroup, TimeGenerated\r\n| join kind=leftouter (\r\n    WVDAgentHealthStatus\r\n    | where _ResourceId contains '${hostPoolName}'\r\n    | parse _ResourceId with \"/subscriptions/\" subscriptionAgentHealth \"/resourcegroups/\" ResourceGroupAgentHealth \"/providers/microsoft.desktopvirtualization/hostpools/\" HostPool\r\n    | parse SessionHostResourceId with \"/subscriptions/\" VMsubscription \"/resourceGroups/\" VMresourceGroup \"/providers/Microsoft.Compute/virtualMachines/\" ComputerName\r\n    | extend ComputerName=tolower(ComputerName)\r\n    | summarize arg_max(TimeGenerated, *) by ComputerName\r\n    | project VMresourceGroup, ComputerName, HostPool\r\n) on ComputerName\r\n",
+                      "timeAggregation": "Count",
+                      "dimensions": [
+                        {
+                          "name": "ComputerName",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "RenderedDescription",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "VMresourceGroup",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "HostPool",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        }
+                      ],
+                      "resourceIdColumn": "_ResourceId",
+                      "operator": "GreaterThanOrEqual",
+                      "threshold": 1,
+                      "failingPeriods": {
+                        "numberOfEvaluationPeriods": 1,
+                        "minFailingPeriodsToAlert": 1
+                      }
+                    }
+                  ]
+                },
+                "actions": "[variables('actions')]"
+              }
+            },
+            {
+              "condition": "[parameters('enableFslogixAlerts')]",
+              "type": "Microsoft.Insights/scheduledQueryRules",
+              "apiVersion": "2022-06-15",
+              "name": "[format('{0}-HP-VM-FSLgxProf-SvcDisabled-{1}', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "displayName": "[format('{0} - FSLogix Service Disabled ({1})', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+                "description": "[format('{0}FSLogix Event ID 60: the FSLogix Profile service is disabled on a session host in {1}. Re-enable and start the FSLogix service immediately.', variables('descriptionHeader'), parameters('hostPoolName'))]",
+                "severity": 1,
+                "enabled": true,
+                "evaluationFrequency": "PT5M",
+                "windowSize": "P1D",
+                "scopes": [
+                  "[parameters('logAnalyticsWorkspaceResourceId')]"
+                ],
+                "autoMitigate": "[parameters('autoResolveAlert')]",
+                "criteria": {
+                  "allOf": [
+                    {
+                      "query": "Event\r\n| where EventLog == \"Microsoft-FSLogix-Apps/Admin\"\r\n| where EventLevelName == \"Warning\"\r\n| where EventID == 60\r\n| parse _ResourceId with \"/subscriptions/\" subscription \"/resourcegroups/\" ResourceGroup \"/providers/microsoft.compute/virtualmachines/\" ComputerName\r\n| extend ComputerName=tolower(ComputerName)\r\n| project ComputerName, RenderedDescription, subscription, ResourceGroup, TimeGenerated\r\n| join kind=leftouter (\r\n    WVDAgentHealthStatus\r\n    | where _ResourceId contains '${hostPoolName}'\r\n    | parse _ResourceId with \"/subscriptions/\" subscriptionAgentHealth \"/resourcegroups/\" ResourceGroupAgentHealth \"/providers/microsoft.desktopvirtualization/hostpools/\" HostPool\r\n    | parse SessionHostResourceId with \"/subscriptions/\" VMsubscription \"/resourceGroups/\" VMresourceGroup \"/providers/Microsoft.Compute/virtualMachines/\" ComputerName\r\n    | extend ComputerName=tolower(ComputerName)\r\n    | summarize arg_max(TimeGenerated, *) by ComputerName\r\n    | project VMresourceGroup, ComputerName, HostPool\r\n) on ComputerName\r\n",
+                      "timeAggregation": "Count",
+                      "dimensions": [
+                        {
+                          "name": "ComputerName",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "RenderedDescription",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "VMresourceGroup",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "HostPool",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        }
+                      ],
+                      "resourceIdColumn": "_ResourceId",
+                      "operator": "GreaterThanOrEqual",
+                      "threshold": 1,
+                      "failingPeriods": {
+                        "numberOfEvaluationPeriods": 1,
+                        "minFailingPeriodsToAlert": 1
+                      }
+                    }
+                  ]
+                },
+                "actions": "[variables('actions')]"
+              }
+            },
+            {
+              "condition": "[parameters('enableFslogixAlerts')]",
+              "type": "Microsoft.Insights/scheduledQueryRules",
+              "apiVersion": "2022-06-15",
+              "name": "[format('{0}-HP-VM-FSLgxProf-DskCmpFail-{1}', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "displayName": "[format('{0} - FSLogix Profile Disk Compaction Failed ({1})', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+                "description": "[format('{0}FSLogix Event ID 62 or 63: profile disk compaction failed on a session host in {1}. The disk was marked for compaction but the operation failed.', variables('descriptionHeader'), parameters('hostPoolName'))]",
+                "severity": 2,
+                "enabled": true,
+                "evaluationFrequency": "PT5M",
+                "windowSize": "P1D",
+                "scopes": [
+                  "[parameters('logAnalyticsWorkspaceResourceId')]"
+                ],
+                "autoMitigate": "[parameters('autoResolveAlert')]",
+                "criteria": {
+                  "allOf": [
+                    {
+                      "query": "Event\r\n| where EventLog == \"Microsoft-FSLogix-Apps/Admin\"\r\n| where EventLevelName == \"Error\"\r\n| where EventID == 62 or EventID == 63\r\n| parse _ResourceId with \"/subscriptions/\" subscription \"/resourcegroups/\" ResourceGroup \"/providers/microsoft.compute/virtualmachines/\" ComputerName\r\n| extend ComputerName=tolower(ComputerName)\r\n| project ComputerName, RenderedDescription, subscription, ResourceGroup, TimeGenerated\r\n| join kind=leftouter (\r\n    WVDAgentHealthStatus\r\n    | where _ResourceId contains '${hostPoolName}'\r\n    | parse _ResourceId with \"/subscriptions/\" subscriptionAgentHealth \"/resourcegroups/\" ResourceGroupAgentHealth \"/providers/microsoft.desktopvirtualization/hostpools/\" HostPool\r\n    | parse SessionHostResourceId with \"/subscriptions/\" VMsubscription \"/resourceGroups/\" VMresourceGroup \"/providers/Microsoft.Compute/virtualMachines/\" ComputerName\r\n    | extend ComputerName=tolower(ComputerName)\r\n    | summarize arg_max(TimeGenerated, *) by ComputerName\r\n    | project VMresourceGroup, ComputerName, HostPool\r\n) on ComputerName\r\n",
+                      "timeAggregation": "Count",
+                      "dimensions": [
+                        {
+                          "name": "ComputerName",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "RenderedDescription",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "VMresourceGroup",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "HostPool",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        }
+                      ],
+                      "resourceIdColumn": "_ResourceId",
+                      "operator": "GreaterThanOrEqual",
+                      "threshold": 1,
+                      "failingPeriods": {
+                        "numberOfEvaluationPeriods": 1,
+                        "minFailingPeriodsToAlert": 1
+                      }
+                    }
+                  ]
+                },
+                "actions": "[variables('actions')]"
+              }
+            },
+            {
+              "condition": "[parameters('enableFslogixAlerts')]",
+              "type": "Microsoft.Insights/scheduledQueryRules",
+              "apiVersion": "2022-06-15",
+              "name": "[format('{0}-HP-VM-FSLgxProf-DskInUse-{1}', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "displayName": "[format('{0} - FSLogix Profile Disk In Use by Another VM ({1})', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+                "description": "[format('{0}FSLogix Event ID 51: a profile VHD is already attached to another VM in {1}. Ensure the user is not connected to multiple host pools sharing the same profile.', variables('descriptionHeader'), parameters('hostPoolName'))]",
+                "severity": 2,
+                "enabled": true,
+                "evaluationFrequency": "PT5M",
+                "windowSize": "P1D",
+                "scopes": [
+                  "[parameters('logAnalyticsWorkspaceResourceId')]"
+                ],
+                "autoMitigate": "[parameters('autoResolveAlert')]",
+                "criteria": {
+                  "allOf": [
+                    {
+                      "query": "Event\r\n| where EventLog == \"Microsoft-FSLogix-Apps/Operational\"\r\n| where EventLevelName == \"Warning\"\r\n| where EventID == 51\r\n| parse _ResourceId with \"/subscriptions/\" subscription \"/resourcegroups/\" ResourceGroup \"/providers/microsoft.compute/virtualmachines/\" ComputerName\r\n| extend ComputerName=tolower(ComputerName)\r\n| project ComputerName, RenderedDescription, subscription, ResourceGroup, TimeGenerated\r\n| join kind=leftouter (\r\n    WVDAgentHealthStatus\r\n    | where _ResourceId contains '${hostPoolName}'\r\n    | parse _ResourceId with \"/subscriptions/\" subscriptionAgentHealth \"/resourcegroups/\" ResourceGroupAgentHealth \"/providers/microsoft.desktopvirtualization/hostpools/\" HostPool\r\n    | parse SessionHostResourceId with \"/subscriptions/\" VMsubscription \"/resourceGroups/\" VMresourceGroup \"/providers/Microsoft.Compute/virtualMachines/\" ComputerName\r\n    | extend ComputerName=tolower(ComputerName)\r\n    | summarize arg_max(TimeGenerated, *) by ComputerName\r\n    | project VMresourceGroup, ComputerName, HostPool\r\n) on ComputerName\r\n",
+                      "timeAggregation": "Count",
+                      "dimensions": [
+                        {
+                          "name": "ComputerName",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "RenderedDescription",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "VMresourceGroup",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "HostPool",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        }
+                      ],
+                      "resourceIdColumn": "_ResourceId",
+                      "operator": "GreaterThanOrEqual",
+                      "threshold": 1,
+                      "failingPeriods": {
+                        "numberOfEvaluationPeriods": 1,
+                        "minFailingPeriodsToAlert": 1
+                      }
+                    }
+                  ]
+                },
+                "actions": "[variables('actions')]"
+              }
+            },
+            {
+              "condition": "[parameters('enableFslogixAlerts')]",
+              "type": "Microsoft.Insights/scheduledQueryRules",
+              "apiVersion": "2022-06-15",
+              "name": "[format('{0}-HP-VM-FSLgxProf-Corrupt-{1}', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "displayName": "[format('{0} - FSLogix Corrupted / Temp Profile ({1})', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+                "description": "[format('{0}FSLogix Event ID 28 in {1}: a user profile VHD is corrupted or could not be mounted and the user was loaded into a temporary profile. Data written during this session will be lost. Investigate and repair the profile VHD.', variables('descriptionHeader'), parameters('hostPoolName'))]",
+                "severity": 2,
+                "enabled": true,
+                "evaluationFrequency": "PT5M",
+                "windowSize": "PT1H",
+                "overrideQueryTimeRange": "P2D",
+                "scopes": [
+                  "[parameters('logAnalyticsWorkspaceResourceId')]"
+                ],
+                "autoMitigate": "[parameters('autoResolveAlert')]",
+                "criteria": {
+                  "allOf": [
+                    {
+                      "query": "let fslogixErrors =\r\n    Event\r\n    | where Source == \"Microsoft-FSLogix-Apps\"\r\n    | where EventID == 28\r\n    | extend ProfileID = tostring(extract(@\"Username:\\s*([^\\s]+)\", 1, RenderedDescription))\r\n    | project EventTime = TimeGenerated, Computer, ProfileID, EventID, RenderedDescription;\r\nlet storageLookup =\r\n    Event\r\n    | where Source == \"Microsoft-FSLogix-Apps\"\r\n    | where RenderedDescription has \".file.core.\"\r\n    | extend StorageAccount = extract(@\"\\\\\\\\([^\\\\]+\\.file\\.core\\.(windows|usgovcloudapi)\\.net)\", 1, RenderedDescription)\r\n    | where isnotempty(StorageAccount)\r\n    | project PathTime = TimeGenerated, Computer, StorageAccount;\r\nfslogixErrors\r\n| join kind=leftouter (storageLookup) on Computer\r\n| extend PathDiff = abs(datetime_diff('minute', EventTime, PathTime))\r\n| where PathDiff <= 60\r\n| join kind=inner (\r\n    WVDConnections\r\n    | where _ResourceId contains '${hostPoolName}'\r\n    | where State == \"Connected\"\r\n    | project ConnTime = TimeGenerated, UserName, SessionHostName, ResourceId = _ResourceId\r\n) on $left.Computer == $right.SessionHostName\r\n| extend TimeDiff = abs(datetime_diff('minute', EventTime, ConnTime))\r\n| where TimeDiff <= 30\r\n| summarize arg_min(TimeDiff, *) by EventTime, Computer\r\n| project\r\n    EventTime,\r\n    UserName,\r\n    ProfileID,\r\n    SessionHostName = Computer,\r\n    StorageAccount,\r\n    EventID,\r\n    RenderedDescription,\r\n    ResourceId\r\n| order by EventTime desc\r\n",
+                      "timeAggregation": "Count",
+                      "dimensions": [
+                        {
+                          "name": "UserName",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "ProfileID",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "SessionHostName",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "StorageAccount",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        }
+                      ],
+                      "resourceIdColumn": "ResourceId",
+                      "operator": "GreaterThanOrEqual",
+                      "threshold": 1,
+                      "failingPeriods": {
+                        "numberOfEvaluationPeriods": 1,
+                        "minFailingPeriodsToAlert": 1
+                      }
+                    }
+                  ]
+                },
+                "actions": "[variables('actions')]"
+              }
+            },
+            {
+              "condition": "[parameters('enableFslogixAlerts')]",
+              "type": "Microsoft.Insights/scheduledQueryRules",
+              "apiVersion": "2022-06-15",
+              "name": "[format('{0}-HP-VM-FSLgxProf-CmpctPre-{1}', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "displayName": "[format('{0} - FSLogix VHD Compaction Pre-Check Failure ({1})', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+                "description": "[format('{0}FSLogix Event ID 58 or 61 in {1}: VHD disk compaction was aborted before starting, either because the host disk lacks free space for the operation (58) or the VHD is in use (61). Profile VHDs will grow unbounded until compaction can complete.', variables('descriptionHeader'), parameters('hostPoolName'))]",
+                "severity": 2,
+                "enabled": true,
+                "evaluationFrequency": "PT5M",
+                "windowSize": "PT1H",
+                "overrideQueryTimeRange": "P2D",
+                "scopes": [
+                  "[parameters('logAnalyticsWorkspaceResourceId')]"
+                ],
+                "autoMitigate": "[parameters('autoResolveAlert')]",
+                "criteria": {
+                  "allOf": [
+                    {
+                      "query": "let fslogixErrors =\r\n    Event\r\n    | where Source == \"Microsoft-FSLogix-Apps\"\r\n    | where EventID in (58, 61)\r\n    | extend\r\n        StorageAccount = extract(@\"\\\\\\\\([^\\\\]+\\.file\\.core\\.(windows|usgovcloudapi)\\.net)\", 1, RenderedDescription),\r\n        ProfileRaw     = extract(@\"profilecontainers\\\\([^\\\\]+)\", 1, RenderedDescription)\r\n    | extend ProfileID = tostring(split(ProfileRaw, \"_\")[0])\r\n    | project EventTime = TimeGenerated, Computer, ProfileID, StorageAccount, EventID, RenderedDescription;\r\nfslogixErrors\r\n| join kind=inner (\r\n    WVDConnections\r\n    | where _ResourceId contains '${hostPoolName}'\r\n    | where State == \"Connected\"\r\n    | project ConnTime = TimeGenerated, UserName, SessionHostName, ResourceId = _ResourceId\r\n) on $left.Computer == $right.SessionHostName\r\n| extend TimeDiff = abs(datetime_diff('minute', EventTime, ConnTime))\r\n| where TimeDiff <= 30\r\n| summarize arg_min(TimeDiff, *) by EventTime, Computer\r\n| project\r\n    EventTime,\r\n    UserName,\r\n    ProfileID,\r\n    SessionHostName = Computer,\r\n    StorageAccount,\r\n    EventID,\r\n    RenderedDescription,\r\n    ResourceId\r\n| order by EventTime desc\r\n",
+                      "timeAggregation": "Count",
+                      "dimensions": [
+                        {
+                          "name": "UserName",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "ProfileID",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "SessionHostName",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "StorageAccount",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "EventID",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        }
+                      ],
+                      "resourceIdColumn": "ResourceId",
+                      "operator": "GreaterThanOrEqual",
+                      "threshold": 1,
+                      "failingPeriods": {
+                        "numberOfEvaluationPeriods": 1,
+                        "minFailingPeriodsToAlert": 1
+                      }
+                    }
+                  ]
+                },
+                "actions": "[variables('actions')]"
+              }
+            },
+            {
+              "condition": "[parameters('enableConnectionAlerts')]",
+              "type": "Microsoft.Insights/scheduledQueryRules",
+              "apiVersion": "2022-06-15",
+              "name": "[format('{0}-HP-Usr-SlowLogon-{1}', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "displayName": "[format('{0} - Slow Session Logon > 2 Minutes ({1})', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+                "description": "[format('{0}A user in {1} took more than 2 minutes from connection start to productive desktop. Common causes: FSLogix profile bloat, GPO processing delay, slow storage, or startup scripts. Review FSLogix profile sizes and storage latency.', variables('descriptionHeader'), parameters('hostPoolName'))]",
+                "severity": 3,
+                "enabled": true,
+                "evaluationFrequency": "PT15M",
+                "windowSize": "PT30M",
+                "overrideQueryTimeRange": "P2D",
+                "scopes": [
+                  "[parameters('logAnalyticsWorkspaceResourceId')]"
+                ],
+                "autoMitigate": "[parameters('autoResolveAlert')]",
+                "criteria": {
+                  "allOf": [
+                    {
+                      "query": "WVDConnections\r\n| where TimeGenerated > ago(30m)\r\n| where _ResourceId contains '${hostPoolName}'\r\n| where State == \"Started\"\r\n| project CorrelationId, UserName, SessionHostName, StartTime = TimeGenerated, ResourceId = _ResourceId\r\n| join kind=inner (\r\n    WVDCheckpoints\r\n    | where _ResourceId contains '${hostPoolName}'\r\n    | where Name =~ \"ShellReady\"\r\n        or (Name =~ \"LaunchExecutable\" and tostring(Parameters.connectionStage) == \"RdpShellAppExecuted\")\r\n        or Name =~ \"RdpShellAppExecuted\"\r\n    | summarize ShellReadyTime = min(TimeGenerated) by CorrelationId\r\n) on CorrelationId\r\n| extend LogonSeconds = datetime_diff('second', ShellReadyTime, StartTime)\r\n| where LogonSeconds > 120\r\n| project\r\n    StartTime,\r\n    UserName,\r\n    SessionHostName,\r\n    LogonSeconds,\r\n    LogonMinutes = round(LogonSeconds / 60.0, 1),\r\n    ResourceId\r\n| order by LogonSeconds desc\r\n",
+                      "timeAggregation": "Count",
+                      "dimensions": [
+                        {
+                          "name": "UserName",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "SessionHostName",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "LogonMinutes",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        }
+                      ],
+                      "resourceIdColumn": "ResourceId",
+                      "operator": "GreaterThanOrEqual",
+                      "threshold": 1,
+                      "failingPeriods": {
+                        "numberOfEvaluationPeriods": 1,
+                        "minFailingPeriodsToAlert": 1
+                      }
+                    }
+                  ]
+                },
+                "actions": "[variables('actions')]"
+              }
+            }
+          ]
+        }
+      },
+      "dependsOn": [
+        "[subscriptionResourceId('Microsoft.Resources/resourceGroups', parameters('resourceGroupName'))]"
+      ]
+    },
+    {
+      "copy": {
+        "name": "vmMetricAlerts",
+        "count": "[length(variables('hostPoolInfoDeduped'))]"
+      },
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('AvdAlerts-VMMetrics-{0}-{1}', last(split(variables('hostPoolInfoDeduped')[copyIndex()].hostPoolResourceId, '/')), variables('deploymentSuffix'))]",
+      "subscriptionId": "[split(variables('hostPoolInfoDeduped')[copyIndex()].vmResourceGroupId, '/')[2]]",
+      "resourceGroup": "[split(variables('hostPoolInfoDeduped')[copyIndex()].vmResourceGroupId, '/')[4]]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "hostPoolName": {
+            "value": "[last(split(variables('hostPoolInfoDeduped')[copyIndex()].hostPoolResourceId, '/'))]"
+          },
+          "vmResourceGroupId": {
+            "value": "[variables('hostPoolInfoDeduped')[copyIndex()].vmResourceGroupId]"
+          },
+          "actionGroupResourceId": {
+            "value": "[parameters('actionGroupResourceId')]"
+          },
+          "alertNamePrefix": {
+            "value": "[parameters('alertNamePrefix')]"
+          },
+          "autoResolveAlert": {
+            "value": "[parameters('autoResolveAlert')]"
+          },
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "enableCpuAlerts": {
+            "value": "[parameters('enableCpuAlerts')]"
+          },
+          "enableMemoryAlerts": {
+            "value": "[parameters('enableMemoryAlerts')]"
+          },
+          "enableOsDiskAlerts": {
+            "value": "[parameters('enableOsDiskAlerts')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.39.26.7824",
+              "templateHash": "1054296779699370075"
+            }
+          },
+          "parameters": {
+            "hostPoolName": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Name of the host pool (used in alert names and descriptions)."
+              }
+            },
+            "vmResourceGroupId": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Resource ID of the resource group containing the session host VMs."
+              }
+            },
+            "actionGroupResourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Resource ID of the Action Group for notifications."
+              }
+            },
+            "alertNamePrefix": {
+              "type": "string",
+              "defaultValue": "AVD",
+              "metadata": {
+                "description": "Optional. Prefix prepended to all alert names."
+              }
+            },
+            "autoResolveAlert": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Whether alert rules auto-resolve when the condition clears."
+              }
+            },
+            "location": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Azure region of the session host VMs (required for multi-resource metric alerts)."
+              }
+            },
+            "enableCpuAlerts": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. When false, CPU alert rules are not deployed."
+              }
+            },
+            "enableMemoryAlerts": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. When false, available memory alert rules are not deployed."
+              }
+            },
+            "enableOsDiskAlerts": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. When false, OS disk bandwidth alert rules are not deployed."
+              }
+            }
+          },
+          "variables": {
+            "descriptionHeader": "FederalAVD - Automated Alert\n",
+            "metricActions": [
+              {
+                "actionGroupId": "[parameters('actionGroupResourceId')]"
+              }
+            ]
+          },
+          "resources": [
+            {
+              "condition": "[parameters('enableCpuAlerts')]",
+              "type": "Microsoft.Insights/metricAlerts",
+              "apiVersion": "2018-03-01",
+              "name": "[format('{0}-HP-VM-HighCPU85Prcnt-{1}', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+              "location": "global",
+              "properties": {
+                "description": "[format('{0}Session host CPU usage exceeded 85% average over 15 minutes in {1}. Review high-CPU processes and consider adding more session hosts or adjusting the scaling plan.', variables('descriptionHeader'), parameters('hostPoolName'))]",
+                "severity": 2,
+                "enabled": true,
+                "scopes": [
+                  "[parameters('vmResourceGroupId')]"
+                ],
+                "evaluationFrequency": "PT5M",
+                "windowSize": "PT15M",
+                "targetResourceType": "microsoft.compute/virtualmachines",
+                "targetResourceRegion": "[parameters('location')]",
+                "criteria": {
+                  "odata.type": "Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria",
+                  "allOf": [
+                    {
+                      "name": "Metric1",
+                      "metricNamespace": "microsoft.compute/virtualmachines",
+                      "metricName": "Percentage CPU",
+                      "operator": "GreaterThan",
+                      "threshold": 85,
+                      "timeAggregation": "Average",
+                      "criterionType": "StaticThresholdCriterion"
+                    }
+                  ]
+                },
+                "autoMitigate": "[parameters('autoResolveAlert')]",
+                "actions": "[variables('metricActions')]"
+              }
+            },
+            {
+              "condition": "[parameters('enableCpuAlerts')]",
+              "type": "Microsoft.Insights/metricAlerts",
+              "apiVersion": "2018-03-01",
+              "name": "[format('{0}-HP-VM-HighCPU95Prcnt-{1}', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+              "location": "global",
+              "properties": {
+                "description": "[format('{0}CRITICAL: Session host CPU usage exceeded 95% average over 15 minutes in {1}. Users on this host are likely experiencing severe performance degradation.', variables('descriptionHeader'), parameters('hostPoolName'))]",
+                "severity": 1,
+                "enabled": true,
+                "scopes": [
+                  "[parameters('vmResourceGroupId')]"
+                ],
+                "evaluationFrequency": "PT5M",
+                "windowSize": "PT15M",
+                "targetResourceType": "microsoft.compute/virtualmachines",
+                "targetResourceRegion": "[parameters('location')]",
+                "criteria": {
+                  "odata.type": "Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria",
+                  "allOf": [
+                    {
+                      "name": "Metric1",
+                      "metricNamespace": "microsoft.compute/virtualmachines",
+                      "metricName": "Percentage CPU",
+                      "operator": "GreaterThan",
+                      "threshold": 95,
+                      "timeAggregation": "Average",
+                      "criterionType": "StaticThresholdCriterion"
+                    }
+                  ]
+                },
+                "autoMitigate": "[parameters('autoResolveAlert')]",
+                "actions": "[variables('metricActions')]"
+              }
+            },
+            {
+              "condition": "[parameters('enableMemoryAlerts')]",
+              "type": "Microsoft.Insights/metricAlerts",
+              "apiVersion": "2018-03-01",
+              "name": "[format('{0}-HP-VM-AvailMemLess2GB-{1}', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+              "location": "global",
+              "properties": {
+                "description": "[format('{0}Available memory on a session host in {1} dropped below 2 GB. Users on this host may experience application slowdowns. Review memory usage and consider adding more session hosts.', variables('descriptionHeader'), parameters('hostPoolName'))]",
+                "severity": 2,
+                "enabled": true,
+                "scopes": [
+                  "[parameters('vmResourceGroupId')]"
+                ],
+                "evaluationFrequency": "PT5M",
+                "windowSize": "PT15M",
+                "targetResourceType": "microsoft.compute/virtualmachines",
+                "targetResourceRegion": "[parameters('location')]",
+                "criteria": {
+                  "odata.type": "Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria",
+                  "allOf": [
+                    {
+                      "name": "Metric1",
+                      "metricNamespace": "microsoft.compute/virtualmachines",
+                      "metricName": "Available Memory Bytes",
+                      "operator": "LessThanOrEqual",
+                      "threshold": 2147483648,
+                      "timeAggregation": "Average",
+                      "criterionType": "StaticThresholdCriterion"
+                    }
+                  ]
+                },
+                "autoMitigate": "[parameters('autoResolveAlert')]",
+                "actions": "[variables('metricActions')]"
+              }
+            },
+            {
+              "condition": "[parameters('enableMemoryAlerts')]",
+              "type": "Microsoft.Insights/metricAlerts",
+              "apiVersion": "2018-03-01",
+              "name": "[format('{0}-HP-VM-AvailMemLess1GB-{1}', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+              "location": "global",
+              "properties": {
+                "description": "[format('{0}CRITICAL: Available memory on a session host in {1} dropped below 1 GB. Users will likely experience application crashes and severe performance issues.', variables('descriptionHeader'), parameters('hostPoolName'))]",
+                "severity": 1,
+                "enabled": true,
+                "scopes": [
+                  "[parameters('vmResourceGroupId')]"
+                ],
+                "evaluationFrequency": "PT5M",
+                "windowSize": "PT15M",
+                "targetResourceType": "microsoft.compute/virtualmachines",
+                "targetResourceRegion": "[parameters('location')]",
+                "criteria": {
+                  "odata.type": "Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria",
+                  "allOf": [
+                    {
+                      "name": "Metric1",
+                      "metricNamespace": "microsoft.compute/virtualmachines",
+                      "metricName": "Available Memory Bytes",
+                      "operator": "LessThanOrEqual",
+                      "threshold": 1073741824,
+                      "timeAggregation": "Average",
+                      "criterionType": "StaticThresholdCriterion"
+                    }
+                  ]
+                },
+                "autoMitigate": "[parameters('autoResolveAlert')]",
+                "actions": "[variables('metricActions')]"
+              }
+            },
+            {
+              "condition": "[parameters('enableOsDiskAlerts')]",
+              "type": "Microsoft.Insights/metricAlerts",
+              "apiVersion": "2018-03-01",
+              "name": "[format('{0}-HP-VM-OSDiskBW85Prcnt-{1}', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+              "location": "global",
+              "properties": {
+                "description": "[format('{0}OS Disk bandwidth consumption on a session host in {1} is at or above 85%. The VM is nearing its disk IOPS limit. Consider moving to a larger or premium disk SKU.', variables('descriptionHeader'), parameters('hostPoolName'))]",
+                "severity": 2,
+                "enabled": true,
+                "scopes": [
+                  "[parameters('vmResourceGroupId')]"
+                ],
+                "evaluationFrequency": "PT5M",
+                "windowSize": "PT15M",
+                "targetResourceType": "microsoft.compute/virtualmachines",
+                "targetResourceRegion": "[parameters('location')]",
+                "criteria": {
+                  "odata.type": "Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria",
+                  "allOf": [
+                    {
+                      "name": "Metric1",
+                      "metricNamespace": "microsoft.compute/virtualmachines",
+                      "metricName": "OS Disk Bandwidth Consumed Percentage",
+                      "operator": "GreaterThanOrEqual",
+                      "threshold": 85,
+                      "timeAggregation": "Average",
+                      "criterionType": "StaticThresholdCriterion",
+                      "dimensions": [
+                        {
+                          "name": "LUN",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "autoMitigate": "[parameters('autoResolveAlert')]",
+                "actions": "[variables('metricActions')]"
+              }
+            },
+            {
+              "condition": "[parameters('enableOsDiskAlerts')]",
+              "type": "Microsoft.Insights/metricAlerts",
+              "apiVersion": "2018-03-01",
+              "name": "[format('{0}-HP-VM-OSDiskBW95Prcnt-{1}', parameters('alertNamePrefix'), parameters('hostPoolName'))]",
+              "location": "global",
+              "properties": {
+                "description": "[format('{0}CRITICAL: OS Disk bandwidth on a session host in {1} is at or above 95%. Users will experience severe I/O latency. Upgrade disk SKU immediately.', variables('descriptionHeader'), parameters('hostPoolName'))]",
+                "severity": 1,
+                "enabled": true,
+                "scopes": [
+                  "[parameters('vmResourceGroupId')]"
+                ],
+                "evaluationFrequency": "PT5M",
+                "windowSize": "PT15M",
+                "targetResourceType": "microsoft.compute/virtualmachines",
+                "targetResourceRegion": "[parameters('location')]",
+                "criteria": {
+                  "odata.type": "Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria",
+                  "allOf": [
+                    {
+                      "name": "Metric1",
+                      "metricNamespace": "microsoft.compute/virtualmachines",
+                      "metricName": "OS Disk Bandwidth Consumed Percentage",
+                      "operator": "GreaterThanOrEqual",
+                      "threshold": 95,
+                      "timeAggregation": "Average",
+                      "criterionType": "StaticThresholdCriterion",
+                      "dimensions": [
+                        {
+                          "name": "LUN",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "autoMitigate": "[parameters('autoResolveAlert')]",
+                "actions": "[variables('metricActions')]"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "copy": {
+        "name": "storageAlerts",
+        "count": "[length(parameters('storageAccountResourceIds'))]"
+      },
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('AvdAlerts-Stor{0}-{1}', copyIndex(), variables('deploymentSuffix'))]",
+      "subscriptionId": "[split(parameters('storageAccountResourceIds')[copyIndex()], '/')[2]]",
+      "resourceGroup": "[split(parameters('storageAccountResourceIds')[copyIndex()], '/')[4]]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "storageAccountResourceId": {
+            "value": "[parameters('storageAccountResourceIds')[copyIndex()]]"
+          },
+          "actionGroupResourceId": {
+            "value": "[parameters('actionGroupResourceId')]"
+          },
+          "alertNamePrefix": {
+            "value": "[parameters('alertNamePrefix')]"
+          },
+          "autoResolveAlert": {
+            "value": "[parameters('autoResolveAlert')]"
+          },
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "logAnalyticsWorkspaceResourceId": {
+            "value": "[parameters('logAnalyticsWorkspaceResourceId')]"
+          },
+          "createStorageLogAlerts": {
+            "value": "[equals(copyIndex(), 0)]"
+          },
+          "enableStorageLatencyAlerts": {
+            "value": "[parameters('enableStorageLatencyAlerts')]"
+          },
+          "enableStorageAvailabilityAlerts": {
+            "value": "[parameters('enableStorageAvailabilityAlerts')]"
+          },
+          "enableStorageThrottlingAlerts": {
+            "value": "[parameters('enableStorageThrottlingAlerts')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.39.26.7824",
+              "templateHash": "18239666501835204059"
+            }
+          },
+          "parameters": {
+            "storageAccountResourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Resource ID of the storage account to monitor."
+              }
+            },
+            "actionGroupResourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Resource ID of the Action Group for notifications."
+              }
+            },
+            "alertNamePrefix": {
+              "type": "string",
+              "defaultValue": "AVD",
+              "metadata": {
+                "description": "Optional. Prefix prepended to all alert names."
+              }
+            },
+            "autoResolveAlert": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Whether alert rules auto-resolve when the condition clears."
+              }
+            },
+            "location": {
+              "type": "string",
+              "metadata": {
+                "description": "Optional. Azure region for the alert rule resources."
+              }
+            },
+            "logAnalyticsWorkspaceResourceId": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Optional. Log Analytics Workspace resource ID. Required when createStorageLogAlerts is true."
+              }
+            },
+            "createStorageLogAlerts": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "Optional. Set true to also create the log-based storage space alerts (driven by the AA runbook). Only set true for one storage account per deployment to avoid duplicate alert rules."
+              }
+            },
+            "enableStorageLatencyAlerts": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. When false, storage server and end-to-end latency alert rules are not deployed."
+              }
+            },
+            "enableStorageAvailabilityAlerts": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. When false, storage account availability alert rules are not deployed."
+              }
+            },
+            "enableStorageThrottlingAlerts": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. When false, file share throttling alert rules are not deployed."
+              }
+            }
+          },
+          "variables": {
+            "storageAccountName": "[last(split(parameters('storageAccountResourceId'), '/'))]",
+            "fileServiceResourceId": "[format('{0}/fileServices/default', parameters('storageAccountResourceId'))]",
+            "descriptionHeader": "FederalAVD - Automated Alert\n",
+            "metricActions": [
+              {
+                "actionGroupId": "[parameters('actionGroupResourceId')]"
+              }
+            ]
+          },
+          "resources": [
+            {
+              "condition": "[parameters('enableStorageLatencyAlerts')]",
+              "type": "Microsoft.Insights/metricAlerts",
+              "apiVersion": "2018-03-01",
+              "name": "[format('{0}-StorAcct-Ovr50msLatncy-{1}', parameters('alertNamePrefix'), variables('storageAccountName'))]",
+              "location": "global",
+              "properties": {
+                "description": "[format('{0}Storage account server latency exceeded 50ms average. This may indicate performance degradation for FSLogix user profiles. Storage account: {1}.', variables('descriptionHeader'), variables('storageAccountName'))]",
+                "severity": 2,
+                "enabled": true,
+                "scopes": [
+                  "[parameters('storageAccountResourceId')]"
+                ],
+                "evaluationFrequency": "PT5M",
+                "windowSize": "PT15M",
+                "targetResourceType": "Microsoft.Storage/storageAccounts",
+                "criteria": {
+                  "odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria",
+                  "allOf": [
+                    {
+                      "name": "Metric1",
+                      "metricName": "SuccessServerLatency",
+                      "operator": "GreaterThan",
+                      "threshold": 50,
+                      "timeAggregation": "Average",
+                      "criterionType": "StaticThresholdCriterion"
+                    }
+                  ]
+                },
+                "autoMitigate": "[parameters('autoResolveAlert')]",
+                "actions": "[variables('metricActions')]"
+              }
+            },
+            {
+              "condition": "[parameters('enableStorageLatencyAlerts')]",
+              "type": "Microsoft.Insights/metricAlerts",
+              "apiVersion": "2018-03-01",
+              "name": "[format('{0}-StorAcct-Ovr100msLatncy-{1}', parameters('alertNamePrefix'), variables('storageAccountName'))]",
+              "location": "global",
+              "properties": {
+                "description": "[format('{0}Storage account server latency exceeded 100ms average. Users may experience slow profile loading or application performance. Storage account: {1}.', variables('descriptionHeader'), variables('storageAccountName'))]",
+                "severity": 1,
+                "enabled": true,
+                "scopes": [
+                  "[parameters('storageAccountResourceId')]"
+                ],
+                "evaluationFrequency": "PT5M",
+                "windowSize": "PT15M",
+                "targetResourceType": "Microsoft.Storage/storageAccounts",
+                "criteria": {
+                  "odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria",
+                  "allOf": [
+                    {
+                      "name": "Metric1",
+                      "metricName": "SuccessServerLatency",
+                      "operator": "GreaterThan",
+                      "threshold": 100,
+                      "timeAggregation": "Average",
+                      "criterionType": "StaticThresholdCriterion"
+                    }
+                  ]
+                },
+                "autoMitigate": "[parameters('autoResolveAlert')]",
+                "actions": "[variables('metricActions')]"
+              }
+            },
+            {
+              "condition": "[parameters('enableStorageLatencyAlerts')]",
+              "type": "Microsoft.Insights/metricAlerts",
+              "apiVersion": "2018-03-01",
+              "name": "[format('{0}-StorAcct-Ovr50msE2ELatncy-{1}', parameters('alertNamePrefix'), variables('storageAccountName'))]",
+              "location": "global",
+              "properties": {
+                "description": "[format('{0}End-to-end latency from session host to storage exceeded 50ms average. This includes network latency and may indicate network path issues. Storage account: {1}.', variables('descriptionHeader'), variables('storageAccountName'))]",
+                "severity": 2,
+                "enabled": true,
+                "scopes": [
+                  "[parameters('storageAccountResourceId')]"
+                ],
+                "evaluationFrequency": "PT5M",
+                "windowSize": "PT15M",
+                "targetResourceType": "Microsoft.Storage/storageAccounts",
+                "criteria": {
+                  "odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria",
+                  "allOf": [
+                    {
+                      "name": "Metric1",
+                      "metricName": "SuccessE2ELatency",
+                      "operator": "GreaterThan",
+                      "threshold": 50,
+                      "timeAggregation": "Average",
+                      "criterionType": "StaticThresholdCriterion"
+                    }
+                  ]
+                },
+                "autoMitigate": "[parameters('autoResolveAlert')]",
+                "actions": "[variables('metricActions')]"
+              }
+            },
+            {
+              "condition": "[parameters('enableStorageLatencyAlerts')]",
+              "type": "Microsoft.Insights/metricAlerts",
+              "apiVersion": "2018-03-01",
+              "name": "[format('{0}-StorAcct-Ovr100msE2ELatncy-{1}', parameters('alertNamePrefix'), variables('storageAccountName'))]",
+              "location": "global",
+              "properties": {
+                "description": "[format('{0}End-to-end latency from session host to storage exceeded 100ms average. Users are likely experiencing degraded profile performance. Storage account: {1}.', variables('descriptionHeader'), variables('storageAccountName'))]",
+                "severity": 1,
+                "enabled": true,
+                "scopes": [
+                  "[parameters('storageAccountResourceId')]"
+                ],
+                "evaluationFrequency": "PT5M",
+                "windowSize": "PT15M",
+                "targetResourceType": "Microsoft.Storage/storageAccounts",
+                "criteria": {
+                  "odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria",
+                  "allOf": [
+                    {
+                      "name": "Metric1",
+                      "metricName": "SuccessE2ELatency",
+                      "operator": "GreaterThan",
+                      "threshold": 100,
+                      "timeAggregation": "Average",
+                      "criterionType": "StaticThresholdCriterion"
+                    }
+                  ]
+                },
+                "autoMitigate": "[parameters('autoResolveAlert')]",
+                "actions": "[variables('metricActions')]"
+              }
+            },
+            {
+              "condition": "[parameters('enableStorageAvailabilityAlerts')]",
+              "type": "Microsoft.Insights/metricAlerts",
+              "apiVersion": "2018-03-01",
+              "name": "[format('{0}-StorAcct-AvailBlw99Prcnt-{1}', parameters('alertNamePrefix'), variables('storageAccountName'))]",
+              "location": "global",
+              "properties": {
+                "description": "[format('{0}Storage account availability dropped below 99%. FSLogix user profiles and MSIX App Attach may be unavailable. Storage account: {1}.', variables('descriptionHeader'), variables('storageAccountName'))]",
+                "severity": 1,
+                "enabled": true,
+                "scopes": [
+                  "[parameters('storageAccountResourceId')]"
+                ],
+                "evaluationFrequency": "PT5M",
+                "windowSize": "PT5M",
+                "targetResourceType": "Microsoft.Storage/storageAccounts",
+                "criteria": {
+                  "odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria",
+                  "allOf": [
+                    {
+                      "name": "Metric1",
+                      "metricName": "Availability",
+                      "operator": "LessThan",
+                      "threshold": 99,
+                      "timeAggregation": "Average",
+                      "criterionType": "StaticThresholdCriterion"
+                    }
+                  ]
+                },
+                "autoMitigate": "[parameters('autoResolveAlert')]",
+                "actions": "[variables('metricActions')]"
+              }
+            },
+            {
+              "condition": "[parameters('enableStorageThrottlingAlerts')]",
+              "type": "Microsoft.Insights/metricAlerts",
+              "apiVersion": "2018-03-01",
+              "name": "[format('{0}-StorAcct-PossThrottle-{1}', parameters('alertNamePrefix'), variables('storageAccountName'))]",
+              "location": "global",
+              "properties": {
+                "description": "[format('{0}Azure Files share is being throttled due to high IOPS. Users may experience slow profile operations. Consider upgrading to a higher tier or increasing the provisioned capacity. Storage account: {1}.', variables('descriptionHeader'), variables('storageAccountName'))]",
+                "severity": 2,
+                "enabled": true,
+                "scopes": [
+                  "[variables('fileServiceResourceId')]"
+                ],
+                "evaluationFrequency": "PT5M",
+                "windowSize": "PT15M",
+                "targetResourceType": "Microsoft.Storage/storageAccounts/fileServices",
+                "criteria": {
+                  "odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria",
+                  "allOf": [
+                    {
+                      "name": "Metric1",
+                      "metricName": "Transactions",
+                      "operator": "GreaterThanOrEqual",
+                      "threshold": 1,
+                      "timeAggregation": "Total",
+                      "criterionType": "StaticThresholdCriterion",
+                      "dimensions": [
+                        {
+                          "name": "ResponseType",
+                          "operator": "Include",
+                          "values": [
+                            "SuccessWithThrottling",
+                            "SuccessWithShareEgressThrottling",
+                            "SuccessWithShareIngressThrottling",
+                            "SuccessWithShareIopsThrottling",
+                            "ClientShareEgressThrottlingError",
+                            "ClientShareIngressThrottlingError",
+                            "ClientShareIopsThrottlingError"
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "autoMitigate": "[parameters('autoResolveAlert')]",
+                "actions": "[variables('metricActions')]"
+              }
+            },
+            {
+              "condition": "[parameters('createStorageLogAlerts')]",
+              "type": "Microsoft.Insights/scheduledQueryRules",
+              "apiVersion": "2022-06-15",
+              "name": "[format('{0}-StorAzFile-LowSpc15Prcnt', parameters('alertNamePrefix'))]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "displayName": "[format('{0} - Azure Files Share Low Space - 15% Remaining', parameters('alertNamePrefix'))]",
+                "description": "[format('{0}An Azure Files share used for FSLogix profiles has 15% or less free space. Review share quota and used space, and increase quota to avoid profile load failures.', variables('descriptionHeader'))]",
+                "severity": 2,
+                "enabled": true,
+                "evaluationFrequency": "PT10M",
+                "windowSize": "PT1H",
+                "overrideQueryTimeRange": "P2D",
+                "scopes": [
+                  "[parameters('logAnalyticsWorkspaceResourceId')]"
+                ],
+                "autoMitigate": "[parameters('autoResolveAlert')]",
+                "criteria": {
+                  "allOf": [
+                    {
+                      "query": "AzureDiagnostics\r\n| where Category has \"JobStreams\" and StreamType_s == \"Output\" and RunbookName_s == \"AvdStorageLogData\"\r\n| where split(ResultDescription, ',')[1] != \"\"\r\n| extend StorageAccount=tostring(split(ResultDescription, ',')[1])\r\n| extend ResourceGroup=tostring(split(ResultDescription, ',')[2])\r\n| extend Share=tostring(split(ResultDescription, ',')[3])\r\n| extend GBShareQuota=split(ResultDescription, ',')[4]\r\n| extend GBUsed=split(ResultDescription, ',')[5]\r\n| extend PercentAvailable=round(toreal(split(ResultDescription, ',')[6]))\r\n| extend ResourceId=tostring(split(ResultDescription, ',')[7])\r\n| summarize arg_max(TimeGenerated, *) by Share\r\n| where PercentAvailable <= 15.00\r\n| project TimeGenerated, ResourceId, StorageAccount, Share, PercentAvailable\r\n",
+                      "timeAggregation": "Count",
+                      "dimensions": [
+                        {
+                          "name": "StorageAccount",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "Share",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        }
+                      ],
+                      "resourceIdColumn": "ResourceId",
+                      "operator": "GreaterThanOrEqual",
+                      "threshold": 1,
+                      "failingPeriods": {
+                        "numberOfEvaluationPeriods": 1,
+                        "minFailingPeriodsToAlert": 1
+                      }
+                    }
+                  ]
+                },
+                "actions": {
+                  "actionGroups": [
+                    "[parameters('actionGroupResourceId')]"
+                  ]
+                }
+              }
+            },
+            {
+              "condition": "[parameters('createStorageLogAlerts')]",
+              "type": "Microsoft.Insights/scheduledQueryRules",
+              "apiVersion": "2022-06-15",
+              "name": "[format('{0}-StorAzFile-LowSpc5Prcnt', parameters('alertNamePrefix'))]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "displayName": "[format('{0} - Azure Files Share Low Space - 5% Remaining', parameters('alertNamePrefix'))]",
+                "description": "[format('{0}CRITICAL: An Azure Files share used for FSLogix profiles has 5% or less free space. New profile loads will fail when the share fills up. Increase quota immediately.', variables('descriptionHeader'))]",
+                "severity": 1,
+                "enabled": true,
+                "evaluationFrequency": "PT10M",
+                "windowSize": "PT1H",
+                "overrideQueryTimeRange": "P2D",
+                "scopes": [
+                  "[parameters('logAnalyticsWorkspaceResourceId')]"
+                ],
+                "autoMitigate": "[parameters('autoResolveAlert')]",
+                "criteria": {
+                  "allOf": [
+                    {
+                      "query": "AzureDiagnostics\r\n| where Category has \"JobStreams\" and StreamType_s == \"Output\" and RunbookName_s == \"AvdStorageLogData\"\r\n| where split(ResultDescription, ',')[1] != \"\"\r\n| extend StorageAccount=tostring(split(ResultDescription, ',')[1])\r\n| extend ResourceGroup=tostring(split(ResultDescription, ',')[2])\r\n| extend Share=tostring(split(ResultDescription, ',')[3])\r\n| extend GBShareQuota=split(ResultDescription, ',')[4]\r\n| extend GBUsed=split(ResultDescription, ',')[5]\r\n| extend PercentAvailable=round(toreal(split(ResultDescription, ',')[6]))\r\n| extend ResourceId=tostring(split(ResultDescription, ',')[7])\r\n| summarize arg_max(TimeGenerated, *) by Share\r\n| where PercentAvailable <= 5.00\r\n| project TimeGenerated, ResourceId, StorageAccount, Share, PercentAvailable\r\n",
+                      "timeAggregation": "Count",
+                      "dimensions": [
+                        {
+                          "name": "StorageAccount",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        },
+                        {
+                          "name": "Share",
+                          "operator": "Include",
+                          "values": [
+                            "*"
+                          ]
+                        }
+                      ],
+                      "resourceIdColumn": "ResourceId",
+                      "operator": "GreaterThanOrEqual",
+                      "threshold": 1,
+                      "failingPeriods": {
+                        "numberOfEvaluationPeriods": 1,
+                        "minFailingPeriodsToAlert": 1
+                      }
+                    }
+                  ]
+                },
+                "actions": {
+                  "actionGroups": [
+                    "[parameters('actionGroupResourceId')]"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      },
+      "dependsOn": [
+        "[subscriptionResourceId('Microsoft.Resources/resourceGroups', parameters('resourceGroupName'))]"
+      ]
+    },
+    {
+      "copy": {
+        "name": "anfAlerts",
+        "count": "[length(parameters('anfVolumeResourceIds'))]"
+      },
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('AvdAlerts-ANF{0}-{1}', copyIndex(), variables('deploymentSuffix'))]",
+      "subscriptionId": "[split(parameters('anfVolumeResourceIds')[copyIndex()], '/')[2]]",
+      "resourceGroup": "[split(parameters('anfVolumeResourceIds')[copyIndex()], '/')[4]]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "anfVolumeResourceId": {
+            "value": "[parameters('anfVolumeResourceIds')[copyIndex()]]"
+          },
+          "actionGroupResourceId": {
+            "value": "[parameters('actionGroupResourceId')]"
+          },
+          "alertNamePrefix": {
+            "value": "[parameters('alertNamePrefix')]"
+          },
+          "autoResolveAlert": {
+            "value": "[parameters('autoResolveAlert')]"
+          },
+          "enableAnfCapacityAlerts": {
+            "value": "[parameters('enableAnfCapacityAlerts')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.39.26.7824",
+              "templateHash": "2289707323753529506"
+            }
+          },
+          "parameters": {
+            "anfVolumeResourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Resource ID of the Azure NetApp Files volume to monitor."
+              }
+            },
+            "actionGroupResourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Resource ID of the Action Group for notifications."
+              }
+            },
+            "alertNamePrefix": {
+              "type": "string",
+              "defaultValue": "AVD",
+              "metadata": {
+                "description": "Optional. Prefix prepended to all alert names."
+              }
+            },
+            "autoResolveAlert": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Whether alert rules auto-resolve when the condition clears."
+              }
+            },
+            "enableAnfCapacityAlerts": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. When false, ANF volume capacity alert rules are not deployed."
+              }
+            }
+          },
+          "variables": {
+            "volumeName": "[last(split(parameters('anfVolumeResourceId'), '/'))]",
+            "descriptionHeader": "FederalAVD - Automated Alert\n",
+            "metricActions": [
+              {
+                "actionGroupId": "[parameters('actionGroupResourceId')]"
+              }
+            ]
+          },
+          "resources": [
+            {
+              "condition": "[parameters('enableAnfCapacityAlerts')]",
+              "type": "Microsoft.Insights/metricAlerts",
+              "apiVersion": "2018-03-01",
+              "name": "[format('{0}-StorLowSpcANF-85Prcnt-{1}', parameters('alertNamePrefix'), variables('volumeName'))]",
+              "location": "global",
+              "properties": {
+                "description": "[format('{0}Azure NetApp Files volume consumed capacity is at or above 85%. Review volume size and expand before it fills up. Volume: {1}.', variables('descriptionHeader'), variables('volumeName'))]",
+                "severity": 2,
+                "enabled": true,
+                "scopes": [
+                  "[parameters('anfVolumeResourceId')]"
+                ],
+                "evaluationFrequency": "PT1H",
+                "windowSize": "PT1H",
+                "targetResourceType": "Microsoft.NetApp/netAppAccounts/capacityPools/volumes",
+                "criteria": {
+                  "odata.type": "Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria",
+                  "allOf": [
+                    {
+                      "name": "Metric1",
+                      "metricNamespace": "microsoft.netapp/netappaccounts/capacitypools/volumes",
+                      "metricName": "VolumeConsumedSizePercentage",
+                      "operator": "GreaterThanOrEqual",
+                      "threshold": 85,
+                      "timeAggregation": "Average",
+                      "criterionType": "StaticThresholdCriterion"
+                    }
+                  ]
+                },
+                "autoMitigate": "[parameters('autoResolveAlert')]",
+                "actions": "[variables('metricActions')]"
+              }
+            },
+            {
+              "condition": "[parameters('enableAnfCapacityAlerts')]",
+              "type": "Microsoft.Insights/metricAlerts",
+              "apiVersion": "2018-03-01",
+              "name": "[format('{0}-StorLowSpcANF-95Prcnt-{1}', parameters('alertNamePrefix'), variables('volumeName'))]",
+              "location": "global",
+              "properties": {
+                "description": "[format('{0}CRITICAL: Azure NetApp Files volume consumed capacity is at or above 95%. Expand the volume capacity immediately to prevent profile load failures. Volume: {1}.', variables('descriptionHeader'), variables('volumeName'))]",
+                "severity": 1,
+                "enabled": true,
+                "scopes": [
+                  "[parameters('anfVolumeResourceId')]"
+                ],
+                "evaluationFrequency": "PT1H",
+                "windowSize": "PT1H",
+                "targetResourceType": "Microsoft.NetApp/netAppAccounts/capacityPools/volumes",
+                "criteria": {
+                  "odata.type": "Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria",
+                  "allOf": [
+                    {
+                      "name": "Metric1",
+                      "metricNamespace": "microsoft.netapp/netappaccounts/capacitypools/volumes",
+                      "metricName": "VolumeConsumedSizePercentage",
+                      "operator": "GreaterThanOrEqual",
+                      "threshold": 95,
+                      "timeAggregation": "Average",
+                      "criterionType": "StaticThresholdCriterion"
+                    }
+                  ]
+                },
+                "autoMitigate": "[parameters('autoResolveAlert')]",
+                "actions": "[variables('metricActions')]"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('AvdAlerts-SvcHealth-{0}', variables('deploymentSuffix'))]",
+      "resourceGroup": "[parameters('resourceGroupName')]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "actionGroupResourceId": {
+            "value": "[parameters('actionGroupResourceId')]"
+          },
+          "alertNamePrefix": {
+            "value": "[parameters('alertNamePrefix')]"
+          },
+          "enableServiceHealthAlerts": {
+            "value": "[parameters('enableServiceHealthAlerts')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.39.26.7824",
+              "templateHash": "3335835430844082378"
+            }
+          },
+          "parameters": {
+            "actionGroupResourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Resource ID of the Action Group for notifications."
+              }
+            },
+            "alertNamePrefix": {
+              "type": "string",
+              "defaultValue": "AVD",
+              "metadata": {
+                "description": "Optional. Prefix prepended to all alert names."
+              }
+            },
+            "enableServiceHealthAlerts": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. When false, Azure Service Health activity log alert rules are not deployed."
+              }
+            }
+          },
+          "variables": {
+            "subscriptionResourceId": "[subscription().id]",
+            "descriptionHeader": "FederalAVD - Automated Alert\n",
+            "alertActions": {
+              "actionGroups": [
+                {
+                  "actionGroupId": "[parameters('actionGroupResourceId')]"
+                }
+              ]
+            }
+          },
+          "resources": [
+            {
+              "condition": "[parameters('enableServiceHealthAlerts')]",
+              "type": "Microsoft.Insights/activityLogAlerts",
+              "apiVersion": "2020-10-01",
+              "name": "[format('{0}-SvcHealth-ServiceIssue', parameters('alertNamePrefix'))]",
+              "location": "global",
+              "properties": {
+                "description": "[format('{0}An active Azure service incident has been detected that may be affecting AVD components in this subscription.', variables('descriptionHeader'))]",
+                "enabled": true,
+                "scopes": [
+                  "[variables('subscriptionResourceId')]"
+                ],
+                "condition": {
+                  "allOf": [
+                    {
+                      "field": "category",
+                      "equals": "ServiceHealth"
+                    },
+                    {
+                      "anyOf": [
+                        {
+                          "field": "properties.incidentType",
+                          "equals": "Incident"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "actions": "[variables('alertActions')]"
+              }
+            },
+            {
+              "condition": "[parameters('enableServiceHealthAlerts')]",
+              "type": "Microsoft.Insights/activityLogAlerts",
+              "apiVersion": "2020-10-01",
+              "name": "[format('{0}-SvcHealth-PlannedMaintenance', parameters('alertNamePrefix'))]",
+              "location": "global",
+              "properties": {
+                "description": "[format('{0}Planned Azure maintenance has been scheduled that may affect AVD components in this subscription.', variables('descriptionHeader'))]",
+                "enabled": true,
+                "scopes": [
+                  "[variables('subscriptionResourceId')]"
+                ],
+                "condition": {
+                  "allOf": [
+                    {
+                      "field": "category",
+                      "equals": "ServiceHealth"
+                    },
+                    {
+                      "anyOf": [
+                        {
+                          "field": "properties.incidentType",
+                          "equals": "Maintenance"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "actions": "[variables('alertActions')]"
+              }
+            },
+            {
+              "condition": "[parameters('enableServiceHealthAlerts')]",
+              "type": "Microsoft.Insights/activityLogAlerts",
+              "apiVersion": "2020-10-01",
+              "name": "[format('{0}-SvcHealth-HealthAdvisory', parameters('alertNamePrefix'))]",
+              "location": "global",
+              "properties": {
+                "description": "[format('{0}An Azure Health Advisory has been issued for services in this subscription. Review to determine if action is required for your AVD environment.', variables('descriptionHeader'))]",
+                "enabled": true,
+                "scopes": [
+                  "[variables('subscriptionResourceId')]"
+                ],
+                "condition": {
+                  "allOf": [
+                    {
+                      "field": "category",
+                      "equals": "ServiceHealth"
+                    },
+                    {
+                      "anyOf": [
+                        {
+                          "field": "properties.incidentType",
+                          "equals": "Informational"
+                        },
+                        {
+                          "field": "properties.incidentType",
+                          "equals": "ActionRequired"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "actions": "[variables('alertActions')]"
+              }
+            },
+            {
+              "condition": "[parameters('enableServiceHealthAlerts')]",
+              "type": "Microsoft.Insights/activityLogAlerts",
+              "apiVersion": "2020-10-01",
+              "name": "[format('{0}-SvcHealth-Security', parameters('alertNamePrefix'))]",
+              "location": "global",
+              "properties": {
+                "description": "[format('{0}An Azure Security Advisory has been issued for services in this subscription. Review immediately for potential security impact on your AVD environment.', variables('descriptionHeader'))]",
+                "enabled": true,
+                "scopes": [
+                  "[variables('subscriptionResourceId')]"
+                ],
+                "condition": {
+                  "allOf": [
+                    {
+                      "field": "category",
+                      "equals": "ServiceHealth"
+                    },
+                    {
+                      "anyOf": [
+                        {
+                          "field": "properties.incidentType",
+                          "equals": "Security"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "actions": "[variables('alertActions')]"
+              }
+            }
+          ]
+        }
+      },
+      "dependsOn": [
+        "[subscriptionResourceId('Microsoft.Resources/resourceGroups', parameters('resourceGroupName'))]"
+      ]
+    }
+  ]
+}

--- a/deployments/add-ons/avdAlerts/modules/anfAlerts.bicep
+++ b/deployments/add-ons/avdAlerts/modules/anfAlerts.bicep
@@ -1,0 +1,104 @@
+// AVD Alerts Add-On - Azure NetApp Files Volume Alert Rules Module
+// Deploys metric alert rules for an ANF volume used for FSLogix profile storage.
+//
+// Alert rules:
+//   - VolumeConsumedSizePercentage >= 85%  (Sev 2)
+//   - VolumeConsumedSizePercentage >= 95%  (Sev 1)
+
+// ========== //
+// Parameters //
+// ========== //
+
+@description('Required. Resource ID of the Azure NetApp Files volume to monitor.')
+param anfVolumeResourceId string
+
+@description('Required. Resource ID of the Action Group for notifications.')
+param actionGroupResourceId string
+
+@description('Optional. Prefix prepended to all alert names.')
+param alertNamePrefix string = 'AVD'
+
+@description('Optional. Whether alert rules auto-resolve when the condition clears.')
+param autoResolveAlert bool = true
+
+@description('Optional. When false, ANF volume capacity alert rules are not deployed.')
+param enableAnfCapacityAlerts bool = true
+
+// ========== //
+// Variables  //
+// ========== //
+
+var volumeName       = last(split(anfVolumeResourceId, '/'))
+var descriptionHeader = 'FederalAVD - Automated Alert\n'
+
+var metricActions = [
+  {
+    actionGroupId: actionGroupResourceId
+  }
+]
+
+// ========== //
+// Resources  //
+// ========== //
+
+// ANF volume consumed >= 85% (Sev 2)
+resource alertAnfVolume85 'Microsoft.Insights/metricAlerts@2018-03-01' = if (enableAnfCapacityAlerts) {
+  name: '${alertNamePrefix}-StorLowSpcANF-85Prcnt-${volumeName}'
+  location: 'global'
+  properties: {
+    description: '${descriptionHeader}Azure NetApp Files volume consumed capacity is at or above 85%. Review volume size and expand before it fills up. Volume: ${volumeName}.'
+    severity: 2
+    enabled: true
+    scopes: [anfVolumeResourceId]
+    evaluationFrequency: 'PT1H'
+    windowSize: 'PT1H'
+    targetResourceType: 'Microsoft.NetApp/netAppAccounts/capacityPools/volumes'
+    criteria: {
+      'odata.type': 'Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria'
+      allOf: [
+        {
+          name: 'Metric1'
+          metricNamespace: 'microsoft.netapp/netappaccounts/capacitypools/volumes'
+          metricName: 'VolumeConsumedSizePercentage'
+          operator: 'GreaterThanOrEqual'
+          threshold: 85
+          timeAggregation: 'Average'
+          criterionType: 'StaticThresholdCriterion'
+        }
+      ]
+    }
+    autoMitigate: autoResolveAlert
+    actions: metricActions
+  }
+}
+
+// ANF volume consumed >= 95% (Sev 1)
+resource alertAnfVolume95 'Microsoft.Insights/metricAlerts@2018-03-01' = if (enableAnfCapacityAlerts) {
+  name: '${alertNamePrefix}-StorLowSpcANF-95Prcnt-${volumeName}'
+  location: 'global'
+  properties: {
+    description: '${descriptionHeader}CRITICAL: Azure NetApp Files volume consumed capacity is at or above 95%. Expand the volume capacity immediately to prevent profile load failures. Volume: ${volumeName}.'
+    severity: 1
+    enabled: true
+    scopes: [anfVolumeResourceId]
+    evaluationFrequency: 'PT1H'
+    windowSize: 'PT1H'
+    targetResourceType: 'Microsoft.NetApp/netAppAccounts/capacityPools/volumes'
+    criteria: {
+      'odata.type': 'Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria'
+      allOf: [
+        {
+          name: 'Metric1'
+          metricNamespace: 'microsoft.netapp/netappaccounts/capacitypools/volumes'
+          metricName: 'VolumeConsumedSizePercentage'
+          operator: 'GreaterThanOrEqual'
+          threshold: 95
+          timeAggregation: 'Average'
+          criterionType: 'StaticThresholdCriterion'
+        }
+      ]
+    }
+    autoMitigate: autoResolveAlert
+    actions: metricActions
+  }
+}

--- a/deployments/add-ons/avdAlerts/modules/automationAccount.bicep
+++ b/deployments/add-ons/avdAlerts/modules/automationAccount.bicep
@@ -1,0 +1,183 @@
+// AVD Alerts Add-On - Automation Account Module
+// Deploys the Automation Account used to collect Azure Files storage space metrics and
+// publish them to Log Analytics for storage-capacity alert rules.
+//
+// Host pool capacity alerts use WVDAgentHealthStatus (native AVD diagnostic data) directly
+// and do NOT require the Automation Account.
+//
+// Resources:
+//   - Automation Account (Basic SKU, system-assigned identity)
+//   - Automation Variables (ResourceManagerUri, StorageAccountResourceIDs)
+//   - Runbook: AvdStorageLogData  (deployed only when hasStorageAccounts is true)
+//   - Schedule: every 15 minutes  (when hasStorageAccounts is true)
+//   - Job Schedule linking runbook to schedule (controlled by createJobSchedules)
+//   - Diagnostic Settings -> Log Analytics workspace
+
+// ========== //
+// Parameters //
+// ========== //
+
+@description('Required. Name of the Automation Account.')
+param automationAccountName string
+
+@description('Required. Azure region for all resources.')
+param location string
+
+@description('Optional. Tags for all resources.')
+param tags object = {}
+
+@description('Required. Azure Resource Manager URI for this cloud (e.g. https://management.azure.com/).')
+param resourceManagerUri string
+
+@description('Required. Resource ID of the Log Analytics Workspace for diagnostic settings and runbook output.')
+param logAnalyticsWorkspaceResourceId string
+
+@description('Optional. URI of the AvdStorageLogData runbook PS1 file. Leave empty for air-gapped environments to create the runbook in an unpublished state.')
+param runbookStorageUri string = ''
+
+@description('Optional. Set to true when StorageAccountResourceIds is not empty.')
+param hasStorageAccounts bool = false
+
+@description('Optional. JSON array string of storage account resource IDs for the storage runbook.')
+param storageAccountResourceIdsJson string = '[]'
+
+@description('Required. UTC timestamp used to compute the first schedule start time.')
+param deploymentTime string
+
+@description('''Optional. Set to true on first deployment to let ARM create the job schedule links.
+Set to false on redeployments. Azure Automation caches job schedule associations by account
+name and raises a Conflict error if ARM tries to create a link that already exists.''')
+param createJobSchedules bool = true
+
+// ========== //
+// Variables  //
+// ========== //
+
+var runbookNameStorage  = 'AvdStorageLogData'
+
+// Schedule start time a few minutes after deployment time
+var scheduleStorageStart = dateTimeAdd(deploymentTime, 'PT5M')
+
+// ========== //
+// Resources  //
+// ========== //
+
+// Automation Account
+resource automationAccount 'Microsoft.Automation/automationAccounts@2023-11-01' = {
+  name: automationAccountName
+  location: location
+  tags: tags
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    sku: {
+      name: 'Basic'
+    }
+    publicNetworkAccess: false
+    disableLocalAuth: true
+  }
+}
+
+// Variable: Resource Manager URI
+resource varResourceManagerUri 'Microsoft.Automation/automationAccounts/variables@2023-11-01' = {
+  parent: automationAccount
+  name: 'ResourceManagerUri'
+  properties: {
+    value: '"${resourceManagerUri}"'
+    isEncrypted: false
+    description: 'Azure Resource Manager endpoint URI for this cloud.'
+  }
+}
+
+// Variable: Storage Account Resource IDs (JSON array)
+resource varStorageAccountResourceIDs 'Microsoft.Automation/automationAccounts/variables@2023-11-01' = if (hasStorageAccounts) {
+  parent: automationAccount
+  name: 'StorageAccountResourceIDs'
+  properties: {
+    value: '"${replace(storageAccountResourceIdsJson, '"', '\\"')}"'
+    isEncrypted: false
+    description: 'JSON array of storage account resource IDs for the storage space collector.'
+  }
+}
+
+// Runbook: AvdStorageLogData
+// Collects Azure Files share usage data and writes to job stream -> Log Analytics.
+resource runbookStorage 'Microsoft.Automation/automationAccounts/runbooks@2023-11-01' = if (hasStorageAccounts) {
+  parent: automationAccount
+  name: runbookNameStorage
+  location: location
+  tags: tags
+  properties: {
+    runbookType: 'PowerShell72'
+    logVerbose: false
+    logProgress: false
+    description: 'Collects Azure Files share usage statistics for Log Analytics alert queries.'
+    publishContentLink: !empty(runbookStorageUri) ? {
+      uri: runbookStorageUri
+    } : null
+  }
+}
+
+// Schedule: AvdStorageLogData (every 15 minutes)
+resource scheduleStorage 'Microsoft.Automation/automationAccounts/schedules@2023-11-01' = if (hasStorageAccounts) {
+  parent: automationAccount
+  name: 'AvdAlerts-Storage-15min'
+  properties: {
+    description: 'Runs the AVD storage data collector every 15 minutes.'
+    startTime: scheduleStorageStart
+    frequency: 'Minute'
+    interval: 15
+    timeZone: 'UTC'
+  }
+}
+
+// Job Schedule: AvdStorageLogData <-> schedule
+resource jobScheduleStorage 'Microsoft.Automation/automationAccounts/jobSchedules@2023-11-01' = if (hasStorageAccounts && createJobSchedules) {
+  parent: automationAccount
+  #disable-next-line use-stable-resource-identifiers
+  name: guid(automationAccount.id, runbookStorage.id, scheduleStorage.id)
+  properties: {
+    runbook: {
+      name: runbookNameStorage
+    }
+    schedule: {
+      name: 'AvdAlerts-Storage-15min'
+    }
+  }
+}
+
+// Diagnostic Settings - send job logs and streams to Log Analytics
+resource diagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name: 'diag-${automationAccountName}'
+  scope: automationAccount
+  properties: {
+    workspaceId: logAnalyticsWorkspaceResourceId
+    logs: [
+      {
+        category: 'JobLogs'
+        enabled: true
+      }
+      {
+        category: 'JobStreams'
+        enabled: true
+      }
+    ]
+    metrics: [
+      {
+        category: 'AllMetrics'
+        enabled: false
+      }
+    ]
+  }
+}
+
+// ======= //
+// Outputs //
+// ======= //
+
+@description('Principal ID of the Automation Account system-assigned managed identity.')
+output principalId string = automationAccount.identity.principalId
+
+@description('Resource ID of the Automation Account.')
+output resourceId string = automationAccount.id

--- a/deployments/add-ons/avdAlerts/modules/hostPoolAlerts.bicep
+++ b/deployments/add-ons/avdAlerts/modules/hostPoolAlerts.bicep
@@ -1,0 +1,1251 @@
+// AVD Alerts Add-On - Host Pool Alert Rules Module
+// Deploys all Log Analytics scheduled query rules for a single AVD host pool.
+//
+// Alert rules in this module (all scoped to the Log Analytics workspace):
+//   Capacity alerts (use WVDAgentHealthStatus - native AVD diagnostic data, no runbook needed):
+//     - Host pool capacity >= 50%  (Sev 3)
+//     - Host pool capacity >= 85%  (Sev 2)
+//     - Host pool capacity >= 95%  (Sev 1)
+//     - Session host unhealthy in personal pool  (Sev 1)
+//   Availability alerts (use WVD diagnostic tables directly):
+//     - No resources available for connection  (Sev 1)
+//     - VM health check failure  (Sev 1)
+//     - User connection failure  (Sev 3)
+//     - Disconnected user > 24 hours  (Sev 2)
+//     - Disconnected user > 72 hours  (Sev 1)
+//   FSLogix alerts (use Event log data from Log Analytics agent / AMA):
+//     - Local disk free space <= 10%  (Sev 2)
+//     - Local disk free space <= 5%   (Sev 1)
+//     - FSLogix profile < 5% free   (EventID 34, Sev 2)
+//     - FSLogix profile < 2% free   (EventID 33, Sev 1)
+//     - FSLogix profile network issue  (EventID 43, Sev 1)
+//     - FSLogix profile disk attach failure  (EventID 52/40, Sev 1)
+//     - FSLogix service disabled  (EventID 60, Sev 1)
+//     - FSLogix disk compaction failed  (EventID 62/63, Sev 2)
+//     - FSLogix profile disk in use by another VM  (EventID 51, Sev 2)
+//     - FSLogix corrupted / temp profile            (EventID 28, Sev 2)
+//     - FSLogix VHD compaction pre-check failure    (EventID 58/61, Sev 2)
+//   Session experience alerts (use WVD checkpoint data directly):
+//     - Slow session logon > 2 minutes              (Sev 3)
+//
+// Capacity alert data source:
+//   WVDAgentHealthStatus is emitted by the AVD agent on each session host and is sent to
+//   Log Analytics via the host pool diagnostic settings (allLogs, configured by the host pool
+//   deployment). It contains ActiveSessions, MaxSessions, AllowNewSessions, and Status per host,
+//   allowing load % to be computed without any Automation Account runbook.
+
+// ========== //
+// Parameters //
+// ========== //
+
+@description('Required. Name of the host pool (not the resource ID).')
+param hostPoolName string
+
+@description('Required. Resource ID of the Log Analytics Workspace.')
+param logAnalyticsWorkspaceResourceId string
+
+@description('Required. Resource ID of the Action Group for notifications.')
+param actionGroupResourceId string
+
+@description('Optional. Prefix prepended to all alert names.')
+param alertNamePrefix string = 'AVD'
+
+@description('Optional. Whether alert rules auto-resolve when the condition clears.')
+param autoResolveAlert bool = true
+
+@description('Optional. Azure region for the alert rule resources.')
+param location string
+
+@description('Optional. When false, host pool capacity alert rules (50%, 85%, 95%) are not deployed.')
+param enableCapacityAlerts bool = true
+
+@description('Optional. When false, host availability and VM health alert rules are not deployed.')
+param enableAvailabilityAlerts bool = true
+
+@description('Optional. When false, user connection failure and disconnected session alert rules are not deployed.')
+param enableConnectionAlerts bool = true
+
+@description('Optional. When false, session host local disk free-space alert rules are not deployed.')
+param enableLocalDiskAlerts bool = true
+
+@description('Optional. When false, FSLogix profile alert rules are not deployed.')
+param enableFslogixAlerts bool = true
+
+// ========== //
+// Variables  //
+// ========== //
+
+var descriptionHeader = 'FederalAVD - Automated Alert\n'
+
+var actions = {
+  actionGroups: [actionGroupResourceId]
+}
+
+// ========== //
+// Resources  //
+// ========== //
+
+// ------------------------------------
+// Capacity Alerts (WVDAgentHealthStatus)
+// ------------------------------------
+
+resource alertCapacity50 'Microsoft.Insights/scheduledQueryRules@2022-06-15' = if (enableCapacityAlerts) {
+  name: '${alertNamePrefix}-HP-Cap-50Prcnt-${hostPoolName}'
+  location: location
+  properties: {
+    displayName: '${alertNamePrefix} - Host Pool Capacity 50% (${hostPoolName})'
+    description: '${descriptionHeader}Host pool is at 50-84% capacity. Review scaling plan and available session hosts for ${hostPoolName}.'
+    severity: 3
+    enabled: true
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT15M'
+    overrideQueryTimeRange: 'P2D'
+    scopes: [logAnalyticsWorkspaceResourceId]
+    autoMitigate: autoResolveAlert
+    criteria: {
+      allOf: [
+        {
+          query: '''
+WVDAgentHealthStatus
+| where TimeGenerated > ago(15m)
+| where _ResourceId contains '${hostPoolName}'
+| summarize arg_max(TimeGenerated, ActiveSessions, MaxSessions, AllowNewSessions, Status, _ResourceId) by SessionHostName
+| summarize
+    TotalActive   = sum(ActiveSessions),
+    TotalCapacity = sum(iff(AllowNewSessions and Status == 'Available', MaxSessions, 0)),
+    ResourceId    = any(_ResourceId)
+| extend LoadPct = iff(TotalCapacity > 0, round(100.0 * TotalActive / TotalCapacity, 0), 0)
+| where TotalCapacity > 0 and LoadPct >= 50 and LoadPct < 85
+'''
+          timeAggregation: 'Count'
+          dimensions: [
+            { name: 'TotalActive',   operator: 'Include', values: ['*'] }
+            { name: 'TotalCapacity', operator: 'Include', values: ['*'] }
+            { name: 'LoadPct',       operator: 'Include', values: ['*'] }
+          ]
+          resourceIdColumn: 'ResourceId'
+          operator: 'GreaterThanOrEqual'
+          threshold: 1
+          failingPeriods: { numberOfEvaluationPeriods: 1, minFailingPeriodsToAlert: 1 }
+        }
+      ]
+    }
+    actions: actions
+  }
+}
+
+resource alertCapacity85 'Microsoft.Insights/scheduledQueryRules@2022-06-15' = if (enableCapacityAlerts) {
+  name: '${alertNamePrefix}-HP-Cap-85Prcnt-${hostPoolName}'
+  location: location
+  properties: {
+    displayName: '${alertNamePrefix} - Host Pool Capacity 85% (${hostPoolName})'
+    description: '${descriptionHeader}Host pool is at 85-94% capacity. Review scaling plan and consider adding session hosts for ${hostPoolName}.'
+    severity: 2
+    enabled: true
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT15M'
+    overrideQueryTimeRange: 'P2D'
+    scopes: [logAnalyticsWorkspaceResourceId]
+    autoMitigate: autoResolveAlert
+    criteria: {
+      allOf: [
+        {
+          query: '''
+WVDAgentHealthStatus
+| where TimeGenerated > ago(15m)
+| where _ResourceId contains '${hostPoolName}'
+| summarize arg_max(TimeGenerated, ActiveSessions, MaxSessions, AllowNewSessions, Status, _ResourceId) by SessionHostName
+| summarize
+    TotalActive   = sum(ActiveSessions),
+    TotalCapacity = sum(iff(AllowNewSessions and Status == 'Available', MaxSessions, 0)),
+    ResourceId    = any(_ResourceId)
+| extend LoadPct = iff(TotalCapacity > 0, round(100.0 * TotalActive / TotalCapacity, 0), 0)
+| where TotalCapacity > 0 and LoadPct >= 85 and LoadPct < 95
+'''
+          timeAggregation: 'Count'
+          dimensions: [
+            { name: 'TotalActive',   operator: 'Include', values: ['*'] }
+            { name: 'TotalCapacity', operator: 'Include', values: ['*'] }
+            { name: 'LoadPct',       operator: 'Include', values: ['*'] }
+          ]
+          resourceIdColumn: 'ResourceId'
+          operator: 'GreaterThanOrEqual'
+          threshold: 1
+          failingPeriods: { numberOfEvaluationPeriods: 1, minFailingPeriodsToAlert: 1 }
+        }
+      ]
+    }
+    actions: actions
+  }
+}
+
+resource alertCapacity95 'Microsoft.Insights/scheduledQueryRules@2022-06-15' = if (enableCapacityAlerts) {
+  name: '${alertNamePrefix}-HP-Cap-95Prcnt-${hostPoolName}'
+  location: location
+  properties: {
+    displayName: '${alertNamePrefix} - Host Pool Capacity 95% (${hostPoolName})'
+    description: '${descriptionHeader}Host pool is at or above 95% capacity. Immediate action required to add session hosts for ${hostPoolName}.'
+    severity: 1
+    enabled: true
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT15M'
+    overrideQueryTimeRange: 'P2D'
+    scopes: [logAnalyticsWorkspaceResourceId]
+    autoMitigate: autoResolveAlert
+    criteria: {
+      allOf: [
+        {
+          query: '''
+WVDAgentHealthStatus
+| where TimeGenerated > ago(15m)
+| where _ResourceId contains '${hostPoolName}'
+| summarize arg_max(TimeGenerated, ActiveSessions, MaxSessions, AllowNewSessions, Status, _ResourceId) by SessionHostName
+| summarize
+    TotalActive   = sum(ActiveSessions),
+    TotalCapacity = sum(iff(AllowNewSessions and Status == 'Available', MaxSessions, 0)),
+    ResourceId    = any(_ResourceId)
+| extend LoadPct = iff(TotalCapacity > 0, round(100.0 * TotalActive / TotalCapacity, 0), 0)
+| where TotalCapacity > 0 and LoadPct >= 95
+'''
+          timeAggregation: 'Count'
+          dimensions: [
+            { name: 'TotalActive',   operator: 'Include', values: ['*'] }
+            { name: 'TotalCapacity', operator: 'Include', values: ['*'] }
+            { name: 'LoadPct',       operator: 'Include', values: ['*'] }
+          ]
+          resourceIdColumn: 'ResourceId'
+          operator: 'GreaterThanOrEqual'
+          threshold: 1
+          failingPeriods: { numberOfEvaluationPeriods: 1, minFailingPeriodsToAlert: 1 }
+        }
+      ]
+    }
+    actions: actions
+  }
+}
+
+// Personal host pool: session host is not in a healthy state
+resource alertPersonalUnhealthy 'Microsoft.Insights/scheduledQueryRules@2022-06-15' = if (enableAvailabilityAlerts) {
+  name: '${alertNamePrefix}-HP-VM-PersnlAssigndUnhlthy-${hostPoolName}'
+  location: location
+  properties: {
+    displayName: '${alertNamePrefix} - Personal Pool Session Host Unhealthy (${hostPoolName})'
+    description: '${descriptionHeader}A session host in the personal host pool ${hostPoolName} is not in an Available state. Investigate the affected VM and its health check results.'
+    severity: 1
+    enabled: true
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT15M'
+    overrideQueryTimeRange: 'P2D'
+    scopes: [logAnalyticsWorkspaceResourceId]
+    autoMitigate: autoResolveAlert
+    criteria: {
+      allOf: [
+        {
+          query: '''
+WVDAgentHealthStatus
+| where TimeGenerated > ago(15m)
+| where _ResourceId contains '${hostPoolName}'
+| summarize arg_max(TimeGenerated, Status, _ResourceId) by SessionHostName
+| where Status != 'Available' and Status != 'Shutdown'
+| project SessionHostName, Status, ResourceId = _ResourceId
+'''
+          timeAggregation: 'Count'
+          dimensions: [
+            { name: 'SessionHostName', operator: 'Include', values: ['*'] }
+            { name: 'Status',          operator: 'Include', values: ['*'] }
+          ]
+          resourceIdColumn: 'ResourceId'
+          operator: 'GreaterThanOrEqual'
+          threshold: 1
+          failingPeriods: { numberOfEvaluationPeriods: 1, minFailingPeriodsToAlert: 1 }
+        }
+      ]
+    }
+    actions: actions
+  }
+}
+
+// ------------------------------------
+// Availability Alerts
+// ------------------------------------
+
+// No resources available - catastrophic, all hosts unhealthy or at capacity
+resource alertNoResourcesAvailable 'Microsoft.Insights/scheduledQueryRules@2022-06-15' = if (enableAvailabilityAlerts) {
+  name: '${alertNamePrefix}-HP-NoResAvail-${hostPoolName}'
+  location: location
+  properties: {
+    displayName: '${alertNamePrefix} - No Resources Available (${hostPoolName})'
+    description: '${descriptionHeader}Catastrophic: no healthy session hosts available for new connections in ${hostPoolName}. Diagnose host pool dependencies immediately.'
+    severity: 1
+    enabled: true
+    evaluationFrequency: 'PT15M'
+    windowSize: 'PT15M'
+    overrideQueryTimeRange: 'P2D'
+    scopes: [logAnalyticsWorkspaceResourceId]
+    autoMitigate: autoResolveAlert
+    criteria: {
+      allOf: [
+        {
+          query: '''
+WVDConnections
+| where TimeGenerated > ago(15m)
+| where _ResourceId contains '${hostPoolName}'
+| project-away TenantId, SourceSystem
+| summarize arg_max(TimeGenerated, *), StartTime = min(iff(State == 'Started', TimeGenerated, datetime(null))), ConnectTime = min(iff(State == 'Connected', TimeGenerated, datetime(null))) by CorrelationId
+| join kind=leftouter (
+    WVDErrors
+    | summarize Errors=make_list(pack('Code', Code, 'CodeSymbolic', CodeSymbolic, 'Time', TimeGenerated, 'Message', Message, 'ServiceError', ServiceError, 'Source', Source)) by CorrelationId
+) on CorrelationId
+| join kind=leftouter (
+    WVDCheckpoints
+    | summarize Checkpoints=make_list(pack('Time', TimeGenerated, 'Name', Name, 'Parameters', Parameters, 'Source', Source)) by CorrelationId
+    | mv-apply Checkpoints on (
+        order by todatetime(Checkpoints['Time']) asc
+        | summarize Checkpoints=make_list(Checkpoints)
+    )
+) on CorrelationId
+| project-away CorrelationId1, CorrelationId2
+| order by TimeGenerated desc
+| where Errors[0].CodeSymbolic == "ConnectionFailedNoHealthyRdshAvailable"
+'''
+          timeAggregation: 'Count'
+          dimensions: [
+            { name: 'UserName', operator: 'Include', values: ['*'] }
+            { name: 'SessionHostName', operator: 'Include', values: ['*'] }
+          ]
+          operator: 'GreaterThanOrEqual'
+          threshold: 1
+          failingPeriods: { numberOfEvaluationPeriods: 1, minFailingPeriodsToAlert: 1 }
+        }
+      ]
+    }
+    actions: actions
+  }
+}
+
+// VM health check failure
+resource alertVMHealthCheck 'Microsoft.Insights/scheduledQueryRules@2022-06-15' = if (enableAvailabilityAlerts) {
+  name: '${alertNamePrefix}-HP-VM-HlthChkFailure-${hostPoolName}'
+  location: location
+  properties: {
+    displayName: '${alertNamePrefix} - VM Health Check Failure (${hostPoolName})'
+    description: '${descriptionHeader}A session host in ${hostPoolName} is available but a dependent resource (domain, FSLogix, SxS stack, URL check) is in a failed state.'
+    severity: 1
+    enabled: true
+    evaluationFrequency: 'PT15M'
+    windowSize: 'PT15M'
+    overrideQueryTimeRange: 'P2D'
+    scopes: [logAnalyticsWorkspaceResourceId]
+    autoMitigate: autoResolveAlert
+    criteria: {
+      allOf: [
+        {
+          query: '''
+let MapToDesc = (idx: long) {
+    case(idx == 0, "DomainJoin",
+    idx == 1, "DomainTrust",
+    idx == 2, "FSLogix",
+    idx == 3, "SxSStack",
+    idx == 4, "URLCheck",
+    idx == 5, "GenevaAgent",
+    idx == 6, "DomainReachable",
+    idx == 7, "WebRTCRedirector",
+    idx == 8, "SxSStackEncryption",
+    idx == 9, "IMDSReachable",
+    idx == 10, "MSIXPackageStaging",
+    "InvalidIndex")
+};
+WVDAgentHealthStatus
+| where TimeGenerated > ago(10m)
+| where Status != 'Available'
+| where AllowNewSessions == true
+| extend CheckFailed = parse_json(SessionHostHealthCheckResult)
+| mv-expand CheckFailed
+| where CheckFailed.AdditionalFailureDetails.ErrorCode != 0
+| extend HealthCheckName = tolong(CheckFailed.HealthCheckName)
+| extend HealthCheckResult = tolong(CheckFailed.HealthCheckResult)
+| extend HealthCheckDesc = MapToDesc(HealthCheckName)
+| where HealthCheckDesc != "InvalidIndex"
+| where _ResourceId contains '${hostPoolName}'
+| parse _ResourceId with "/subscriptions/" subscription "/resourcegroups/" HostPoolResourceGroup "/providers/microsoft.desktopvirtualization/hostpools/" HostPool
+| parse SessionHostResourceId with "/subscriptions/" HostSubscription "/resourceGroups/" SessionHostRG "/providers/Microsoft.Compute/virtualMachines/" SessionHostName
+'''
+          timeAggregation: 'Count'
+          dimensions: [
+            { name: 'SessionHostName', operator: 'Include', values: ['*'] }
+            { name: 'HealthCheckDesc', operator: 'Include', values: ['*'] }
+            { name: 'HostPool', operator: 'Include', values: ['*'] }
+            { name: 'SessionHostRG', operator: 'Include', values: ['*'] }
+          ]
+          operator: 'GreaterThanOrEqual'
+          threshold: 1
+          failingPeriods: { numberOfEvaluationPeriods: 1, minFailingPeriodsToAlert: 1 }
+        }
+      ]
+    }
+    actions: actions
+  }
+}
+
+// User connection failed
+resource alertConnectionFailed 'Microsoft.Insights/scheduledQueryRules@2022-06-15' = if (enableConnectionAlerts) {
+  name: '${alertNamePrefix}-HP-Usr-ConnctnFailed-${hostPoolName}'
+  location: location
+  properties: {
+    displayName: '${alertNamePrefix} - User Connection Failed (${hostPoolName})'
+    description: '${descriptionHeader}A user failed to connect to a session host in ${hostPoolName}. If frequent, investigate network latency (>150ms) and session host availability.'
+    severity: 3
+    enabled: true
+    evaluationFrequency: 'PT15M'
+    windowSize: 'PT15M'
+    overrideQueryTimeRange: 'P2D'
+    scopes: [logAnalyticsWorkspaceResourceId]
+    autoMitigate: autoResolveAlert
+    criteria: {
+      allOf: [
+        {
+          query: '''
+WVDConnections
+| project-away TenantId, SourceSystem
+| summarize arg_max(TimeGenerated, *), StartTime = min(iff(State == 'Started', TimeGenerated, datetime(null))), ConnectTime = min(iff(State == 'Connected', TimeGenerated, datetime(null))) by CorrelationId
+| join kind=leftouter (
+    WVDErrors
+    | summarize Errors=make_list(pack('Code', Code, 'CodeSymbolic', CodeSymbolic, 'Time', TimeGenerated, 'Message', Message, 'ServiceError', ServiceError, 'Source', Source)) by CorrelationId
+) on CorrelationId
+| join kind=leftouter (
+    WVDCheckpoints
+    | summarize Checkpoints=make_list(pack('Time', TimeGenerated, 'Name', Name, 'Parameters', Parameters, 'Source', Source)) by CorrelationId
+    | mv-apply Checkpoints on (
+        order by todatetime(Checkpoints['Time']) asc
+        | summarize Checkpoints=make_list(Checkpoints)
+    )
+) on CorrelationId
+| project-away CorrelationId1, CorrelationId2
+| order by TimeGenerated desc
+| where TimeGenerated > ago(15m)
+| extend ResourceGroup=tostring(split(_ResourceId, '/')[4])
+| extend HostPool=tostring(split(_ResourceId, '/')[8])
+| where HostPool =~ '${hostPoolName}'
+| where isnotempty(Errors)
+| extend ErrorShort=tostring(Errors[0].CodeSymbolic)
+| extend ErrorMessage=tostring(Errors[0].Message)
+| project TimeGenerated, HostPool, ResourceGroup, UserName, ClientOS, ClientVersion, ClientSideIPAddress, ConnectionType, ErrorShort, ErrorMessage
+'''
+          timeAggregation: 'Count'
+          dimensions: [
+            { name: 'HostPool', operator: 'Include', values: ['*'] }
+            { name: 'UserName', operator: 'Include', values: ['*'] }
+            { name: 'ErrorShort', operator: 'Include', values: ['*'] }
+          ]
+          operator: 'GreaterThanOrEqual'
+          threshold: 1
+          failingPeriods: { numberOfEvaluationPeriods: 1, minFailingPeriodsToAlert: 1 }
+        }
+      ]
+    }
+    actions: actions
+  }
+}
+
+// Disconnected user > 24 hours
+resource alertDisconnectedUser24h 'Microsoft.Insights/scheduledQueryRules@2022-06-15' = if (enableConnectionAlerts) {
+  name: '${alertNamePrefix}-HP-DiscUser24Hrs-${hostPoolName}'
+  location: location
+  properties: {
+    displayName: '${alertNamePrefix} - Disconnected User Over 24 Hours (${hostPoolName})'
+    description: '${descriptionHeader}A user in ${hostPoolName} has a disconnected session lasting more than 24 hours. Verify Remote Desktop session limit policies are applied. This could affect scaling plans.'
+    severity: 2
+    enabled: true
+    evaluationFrequency: 'PT1H'
+    windowSize: 'PT1H'
+    overrideQueryTimeRange: 'P2D'
+    scopes: [logAnalyticsWorkspaceResourceId]
+    autoMitigate: autoResolveAlert
+    criteria: {
+      allOf: [
+        {
+          query: '''
+WVDConnections
+| where TimeGenerated > ago(24h)
+| where State == "Connected"
+| where _ResourceId contains '${hostPoolName}'
+| project CorrelationId, UserName, ConnectionType, StartTime=TimeGenerated, SessionHostName
+| join (
+    WVDConnections
+    | where State == "Completed"
+    | project EndTime=TimeGenerated, CorrelationId
+) on CorrelationId
+| project Duration = EndTime - StartTime, ConnectionType, UserName, SessionHostName
+| where Duration >= timespan(24:00:00)
+| sort by Duration desc
+'''
+          timeAggregation: 'Count'
+          dimensions: [
+            { name: 'UserName', operator: 'Include', values: ['*'] }
+            { name: 'SessionHostName', operator: 'Include', values: ['*'] }
+          ]
+          operator: 'GreaterThanOrEqual'
+          threshold: 1
+          failingPeriods: { numberOfEvaluationPeriods: 1, minFailingPeriodsToAlert: 1 }
+        }
+      ]
+    }
+    actions: actions
+  }
+}
+
+// Disconnected user > 72 hours
+resource alertDisconnectedUser72h 'Microsoft.Insights/scheduledQueryRules@2022-06-15' = if (enableConnectionAlerts) {
+  name: '${alertNamePrefix}-HP-DiscUser72Hrs-${hostPoolName}'
+  location: location
+  properties: {
+    displayName: '${alertNamePrefix} - Disconnected User Over 72 Hours (${hostPoolName})'
+    description: '${descriptionHeader}A user in ${hostPoolName} has a disconnected session lasting more than 72 hours. This likely indicates stale sessions blocking scaling automation. Verify session limit policies.'
+    severity: 1
+    enabled: true
+    evaluationFrequency: 'PT1H'
+    windowSize: 'PT1H'
+    overrideQueryTimeRange: 'P2D'
+    scopes: [logAnalyticsWorkspaceResourceId]
+    autoMitigate: autoResolveAlert
+    criteria: {
+      allOf: [
+        {
+          query: '''
+WVDConnections
+| where TimeGenerated > ago(24h)
+| where State == "Connected"
+| where _ResourceId contains '${hostPoolName}'
+| project CorrelationId, UserName, ConnectionType, StartTime=TimeGenerated, SessionHostName
+| join (
+    WVDConnections
+    | where State == "Completed"
+    | project EndTime=TimeGenerated, CorrelationId
+) on CorrelationId
+| project Duration = EndTime - StartTime, ConnectionType, UserName, SessionHostName
+| where Duration >= timespan(72:00:00)
+| sort by Duration desc
+'''
+          timeAggregation: 'Count'
+          dimensions: [
+            { name: 'UserName', operator: 'Include', values: ['*'] }
+            { name: 'SessionHostName', operator: 'Include', values: ['*'] }
+          ]
+          operator: 'GreaterThanOrEqual'
+          threshold: 1
+          failingPeriods: { numberOfEvaluationPeriods: 1, minFailingPeriodsToAlert: 1 }
+        }
+      ]
+    }
+    actions: actions
+  }
+}
+
+// ------------------------------------
+// Local Disk Space Alerts
+// ------------------------------------
+
+// Local C: drive free space <= 10%
+resource alertLocalDiskFree10 'Microsoft.Insights/scheduledQueryRules@2022-06-15' = if (enableLocalDiskAlerts) {
+  name: '${alertNamePrefix}-HP-VM-LocDskFree10Prcnt-${hostPoolName}'
+  location: location
+  properties: {
+    displayName: '${alertNamePrefix} - VM Local Disk Free <= 10% (${hostPoolName})'
+    description: '${descriptionHeader}A session host in ${hostPoolName} has 10% or less free space on the C: drive. Review local profiles, temp files, and application logs consuming disk space.'
+    severity: 2
+    enabled: true
+    evaluationFrequency: 'PT15M'
+    windowSize: 'PT15M'
+    overrideQueryTimeRange: 'P2D'
+    scopes: [logAnalyticsWorkspaceResourceId]
+    autoMitigate: autoResolveAlert
+    criteria: {
+      allOf: [
+        {
+          query: '''
+Perf
+| where TimeGenerated > ago(15m)
+| where ObjectName == "LogicalDisk" and CounterName == "% Free Space"
+| where InstanceName !contains "D:" and InstanceName !contains "_Total"
+| where CounterValue <= 10.00
+| parse _ResourceId with "/subscriptions/" subscription "/resourcegroups/" ResourceGroup "/providers/microsoft.compute/virtualmachines/" ComputerName
+| summarize arg_max(TimeGenerated, *) by ComputerName
+| extend ComputerName=tolower(ComputerName)
+| project ComputerName, CounterValue, subscription, ResourceGroup, TimeGenerated
+| join kind=leftouter (
+    WVDAgentHealthStatus
+    | where TimeGenerated > ago(15m)
+    | where _ResourceId contains '${hostPoolName}'
+    | parse _ResourceId with "/subscriptions/" subscriptionAgentHealth "/resourcegroups/" ResourceGroupAgentHealth "/providers/microsoft.desktopvirtualization/hostpools/" HostPool
+    | parse SessionHostResourceId with "/subscriptions/" VMsubscription "/resourceGroups/" VMresourceGroup "/providers/Microsoft.Compute/virtualMachines/" ComputerName
+    | extend ComputerName=tolower(ComputerName)
+    | summarize arg_max(TimeGenerated, *) by ComputerName
+    | project VMresourceGroup, ComputerName, HostPool, _ResourceId
+) on ComputerName
+| where ComputerName1 contains ComputerName
+'''
+          timeAggregation: 'Count'
+          dimensions: [
+            { name: 'ComputerName', operator: 'Include', values: ['*'] }
+            { name: 'VMresourceGroup', operator: 'Include', values: ['*'] }
+            { name: 'HostPool', operator: 'Include', values: ['*'] }
+          ]
+          resourceIdColumn: '_ResourceId'
+          operator: 'GreaterThanOrEqual'
+          threshold: 1
+          failingPeriods: { numberOfEvaluationPeriods: 1, minFailingPeriodsToAlert: 1 }
+        }
+      ]
+    }
+    actions: actions
+  }
+}
+
+// Local C: drive free space <= 5%
+resource alertLocalDiskFree5 'Microsoft.Insights/scheduledQueryRules@2022-06-15' = if (enableLocalDiskAlerts) {
+  name: '${alertNamePrefix}-HP-VM-LocDskFree5Prcnt-${hostPoolName}'
+  location: location
+  properties: {
+    displayName: '${alertNamePrefix} - VM Local Disk Free <= 5% (${hostPoolName})'
+    description: '${descriptionHeader}CRITICAL: A session host in ${hostPoolName} has 5% or less free space on the C: drive. Immediate action required to free disk space.'
+    severity: 1
+    enabled: true
+    evaluationFrequency: 'PT15M'
+    windowSize: 'PT15M'
+    overrideQueryTimeRange: 'P2D'
+    scopes: [logAnalyticsWorkspaceResourceId]
+    autoMitigate: autoResolveAlert
+    criteria: {
+      allOf: [
+        {
+          query: '''
+Perf
+| where TimeGenerated > ago(15m)
+| where ObjectName == "LogicalDisk" and CounterName == "% Free Space"
+| where InstanceName !contains "D:" and InstanceName !contains "_Total"
+| where CounterValue <= 5.00
+| parse _ResourceId with "/subscriptions/" subscription "/resourcegroups/" ResourceGroup "/providers/microsoft.compute/virtualmachines/" ComputerName
+| summarize arg_max(TimeGenerated, *) by ComputerName
+| extend ComputerName=tolower(ComputerName)
+| project ComputerName, CounterValue, subscription, ResourceGroup, TimeGenerated
+| join kind=leftouter (
+    WVDAgentHealthStatus
+    | where TimeGenerated > ago(15m)
+    | where _ResourceId contains '${hostPoolName}'
+    | parse _ResourceId with "/subscriptions/" subscriptionAgentHealth "/resourcegroups/" ResourceGroupAgentHealth "/providers/microsoft.desktopvirtualization/hostpools/" HostPool
+    | parse SessionHostResourceId with "/subscriptions/" VMsubscription "/resourceGroups/" VMresourceGroup "/providers/Microsoft.Compute/virtualMachines/" ComputerName
+    | extend ComputerName=tolower(ComputerName)
+    | summarize arg_max(TimeGenerated, *) by ComputerName
+    | project VMresourceGroup, ComputerName, HostPool, _ResourceId
+) on ComputerName
+| where ComputerName1 contains ComputerName
+'''
+          timeAggregation: 'Count'
+          dimensions: [
+            { name: 'ComputerName', operator: 'Include', values: ['*'] }
+            { name: 'VMresourceGroup', operator: 'Include', values: ['*'] }
+            { name: 'HostPool', operator: 'Include', values: ['*'] }
+          ]
+          resourceIdColumn: '_ResourceId'
+          operator: 'GreaterThanOrEqual'
+          threshold: 1
+          failingPeriods: { numberOfEvaluationPeriods: 1, minFailingPeriodsToAlert: 1 }
+        }
+      ]
+    }
+    actions: actions
+  }
+}
+
+// ------------------------------------
+// FSLogix Profile Alerts
+// ------------------------------------
+
+// FSLogix profile < 5% free (EventID 34, Warning)
+resource alertFSLogixProfile5PctFree 'Microsoft.Insights/scheduledQueryRules@2022-06-15' = if (enableFslogixAlerts) {
+  name: '${alertNamePrefix}-HP-VM-FSLgxProf5PrcntFree-${hostPoolName}'
+  location: location
+  properties: {
+    displayName: '${alertNamePrefix} - FSLogix Profile < 5% Free Space (${hostPoolName})'
+    description: '${descriptionHeader}FSLogix Event ID 34: a user profile VHD in ${hostPoolName} has less than 5% free space. Expand the VHD or clean up profile data.'
+    severity: 2
+    enabled: true
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT5M'
+    scopes: [logAnalyticsWorkspaceResourceId]
+    autoMitigate: autoResolveAlert
+    criteria: {
+      allOf: [
+        {
+          query: '''
+Event
+| where EventLog == "Microsoft-FSLogix-Apps/Admin"
+| where EventLevelName == "Warning"
+| where EventID == 34
+| parse _ResourceId with "/subscriptions/" subscription "/resourcegroups/" ResourceGroup "/providers/microsoft.compute/virtualmachines/" ComputerName
+| extend ComputerName=tolower(ComputerName)
+| project ComputerName, RenderedDescription, subscription, ResourceGroup, TimeGenerated
+| join kind=leftouter (
+    WVDAgentHealthStatus
+    | where _ResourceId contains '${hostPoolName}'
+    | parse _ResourceId with "/subscriptions/" subscriptionAgentHealth "/resourcegroups/" ResourceGroupAgentHealth "/providers/microsoft.desktopvirtualization/hostpools/" HostPool
+    | parse SessionHostResourceId with "/subscriptions/" VMsubscription "/resourceGroups/" VMresourceGroup "/providers/Microsoft.Compute/virtualMachines/" ComputerName
+    | extend ComputerName=tolower(ComputerName)
+    | summarize arg_max(TimeGenerated, *) by ComputerName
+    | project VMresourceGroup, ComputerName, HostPool
+) on ComputerName
+'''
+          timeAggregation: 'Count'
+          dimensions: [
+            { name: 'ComputerName', operator: 'Include', values: ['*'] }
+            { name: 'RenderedDescription', operator: 'Include', values: ['*'] }
+            { name: 'VMresourceGroup', operator: 'Include', values: ['*'] }
+            { name: 'HostPool', operator: 'Include', values: ['*'] }
+          ]
+          operator: 'GreaterThanOrEqual'
+          threshold: 1
+          failingPeriods: { numberOfEvaluationPeriods: 1, minFailingPeriodsToAlert: 1 }
+        }
+      ]
+    }
+    actions: actions
+  }
+}
+
+// FSLogix profile < 2% free (EventID 33, Error) - enriched with user and storage account context
+// Joins FSLogix errors with WVDConnections to identify which user's profile is critically full,
+// on which session host, and pointing to which storage account.
+resource alertFSLogixProfile2PctFree 'Microsoft.Insights/scheduledQueryRules@2022-06-15' = if (enableFslogixAlerts) {
+  name: '${alertNamePrefix}-HP-VM-FSLgxProf2PrcntFree-${hostPoolName}'
+  location: location
+  properties: {
+    displayName: '${alertNamePrefix} - FSLogix Profile < 2% Free Space (${hostPoolName})'
+    description: '${descriptionHeader}CRITICAL: FSLogix Event ID 33 in ${hostPoolName}: a user profile VHD has less than 2% free space. The alert includes the affected user, profile container, and storage account. Expand the VHD or clean up profile data immediately.'
+    severity: 1
+    enabled: true
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT1H'
+    overrideQueryTimeRange: 'P2D'
+    scopes: [logAnalyticsWorkspaceResourceId]
+    autoMitigate: autoResolveAlert
+    criteria: {
+      allOf: [
+        {
+          query: '''
+let fslogixErrors =
+    Event
+    | where Source == "Microsoft-FSLogix-Apps"
+    | where EventID == 33
+    | extend
+        StorageAccount = extract(@"\\\\([^\\]+\.file\.core\.(windows|usgovcloudapi)\.net)", 1, RenderedDescription),
+        ProfileRaw     = extract(@"profilecontainers\\([^\\]+)", 1, RenderedDescription)
+    | extend ProfileID = tostring(split(ProfileRaw, "_")[0])
+    | project EventTime = TimeGenerated, Computer, ProfileID, StorageAccount, EventID, RenderedDescription;
+fslogixErrors
+| join kind=inner (
+    WVDConnections
+    | where _ResourceId contains '${hostPoolName}'
+    | where State == "Connected"
+    | project ConnTime = TimeGenerated, UserName, SessionHostName, ResourceId = _ResourceId
+) on $left.Computer == $right.SessionHostName
+| extend TimeDiff = abs(datetime_diff('minute', EventTime, ConnTime))
+| where TimeDiff <= 30
+| summarize arg_min(TimeDiff, *) by EventTime, Computer
+| project
+    EventTime,
+    UserName,
+    ProfileID,
+    SessionHostName = Computer,
+    StorageAccount,
+    EventID,
+    RenderedDescription,
+    ResourceId
+| order by EventTime desc
+'''
+          timeAggregation: 'Count'
+          dimensions: [
+            { name: 'UserName',        operator: 'Include', values: ['*'] }
+            { name: 'ProfileID',       operator: 'Include', values: ['*'] }
+            { name: 'SessionHostName', operator: 'Include', values: ['*'] }
+            { name: 'StorageAccount',  operator: 'Include', values: ['*'] }
+          ]
+          resourceIdColumn: 'ResourceId'
+          operator: 'GreaterThanOrEqual'
+          threshold: 1
+          failingPeriods: { numberOfEvaluationPeriods: 1, minFailingPeriodsToAlert: 1 }
+        }
+      ]
+    }
+    actions: actions
+  }
+}
+
+// FSLogix profile network issue (EventID 43)
+resource alertFSLogixNetworkIssue 'Microsoft.Insights/scheduledQueryRules@2022-06-15' = if (enableFslogixAlerts) {
+  name: '${alertNamePrefix}-HP-VM-FSLgxProf-NetwrkIssue-${hostPoolName}'
+  location: location
+  properties: {
+    displayName: '${alertNamePrefix} - FSLogix Profile Network Issue (${hostPoolName})'
+    description: '${descriptionHeader}FSLogix Event ID 43: a session host in ${hostPoolName} cannot reach the FSLogix profile storage. Verify network connectivity between the session hosts and the storage account.'
+    severity: 1
+    enabled: true
+    evaluationFrequency: 'PT5M'
+    windowSize: 'P1D'
+    scopes: [logAnalyticsWorkspaceResourceId]
+    autoMitigate: autoResolveAlert
+    criteria: {
+      allOf: [
+        {
+          query: '''
+Event
+| where EventLog == "Microsoft-FSLogix-Apps/Admin"
+| where EventLevelName == "Error"
+| where EventID == 43
+| parse _ResourceId with "/subscriptions/" subscription "/resourcegroups/" ResourceGroup "/providers/microsoft.compute/virtualmachines/" ComputerName
+| extend ComputerName=tolower(ComputerName)
+| project ComputerName, RenderedDescription, subscription, ResourceGroup, TimeGenerated
+| join kind=leftouter (
+    WVDAgentHealthStatus
+    | where _ResourceId contains '${hostPoolName}'
+    | parse _ResourceId with "/subscriptions/" subscriptionAgentHealth "/resourcegroups/" ResourceGroupAgentHealth "/providers/microsoft.desktopvirtualization/hostpools/" HostPool
+    | parse SessionHostResourceId with "/subscriptions/" VMsubscription "/resourceGroups/" VMresourceGroup "/providers/Microsoft.Compute/virtualMachines/" ComputerName
+    | extend ComputerName=tolower(ComputerName)
+    | summarize arg_max(TimeGenerated, *) by ComputerName
+    | project VMresourceGroup, ComputerName, HostPool
+) on ComputerName
+'''
+          timeAggregation: 'Count'
+          dimensions: [
+            { name: 'ComputerName', operator: 'Include', values: ['*'] }
+            { name: 'RenderedDescription', operator: 'Include', values: ['*'] }
+            { name: 'VMresourceGroup', operator: 'Include', values: ['*'] }
+            { name: 'HostPool', operator: 'Include', values: ['*'] }
+          ]
+          resourceIdColumn: '_ResourceId'
+          operator: 'GreaterThanOrEqual'
+          threshold: 1
+          failingPeriods: { numberOfEvaluationPeriods: 1, minFailingPeriodsToAlert: 1 }
+        }
+      ]
+    }
+    actions: actions
+  }
+}
+
+// FSLogix profile disk failed to attach (EventID 52 or 40)
+resource alertFSLogixDiskAttachFailed 'Microsoft.Insights/scheduledQueryRules@2022-06-15' = if (enableFslogixAlerts) {
+  name: '${alertNamePrefix}-HP-VM-FSLgxProf-FailAttVHD-${hostPoolName}'
+  location: location
+  properties: {
+    displayName: '${alertNamePrefix} - FSLogix Profile Disk Failed to Attach (${hostPoolName})'
+    description: '${descriptionHeader}FSLogix Event ID 52 or 40: the profile VHD failed to attach for a session host in ${hostPoolName}. Investigate FSLogix errors for details.'
+    severity: 1
+    enabled: true
+    evaluationFrequency: 'PT5M'
+    windowSize: 'P1D'
+    scopes: [logAnalyticsWorkspaceResourceId]
+    autoMitigate: autoResolveAlert
+    criteria: {
+      allOf: [
+        {
+          query: '''
+Event
+| where EventLog == "Microsoft-FSLogix-Apps/Admin"
+| where EventLevelName == "Error"
+| where EventID == 52 or EventID == 40
+| parse _ResourceId with "/subscriptions/" subscription "/resourcegroups/" ResourceGroup "/providers/microsoft.compute/virtualmachines/" ComputerName
+| extend ComputerName=tolower(ComputerName)
+| project ComputerName, RenderedDescription, subscription, ResourceGroup, TimeGenerated
+| join kind=leftouter (
+    WVDAgentHealthStatus
+    | where _ResourceId contains '${hostPoolName}'
+    | parse _ResourceId with "/subscriptions/" subscriptionAgentHealth "/resourcegroups/" ResourceGroupAgentHealth "/providers/microsoft.desktopvirtualization/hostpools/" HostPool
+    | parse SessionHostResourceId with "/subscriptions/" VMsubscription "/resourceGroups/" VMresourceGroup "/providers/Microsoft.Compute/virtualMachines/" ComputerName
+    | extend ComputerName=tolower(ComputerName)
+    | summarize arg_max(TimeGenerated, *) by ComputerName
+    | project VMresourceGroup, ComputerName, HostPool
+) on ComputerName
+'''
+          timeAggregation: 'Count'
+          dimensions: [
+            { name: 'ComputerName', operator: 'Include', values: ['*'] }
+            { name: 'RenderedDescription', operator: 'Include', values: ['*'] }
+            { name: 'VMresourceGroup', operator: 'Include', values: ['*'] }
+            { name: 'HostPool', operator: 'Include', values: ['*'] }
+          ]
+          resourceIdColumn: '_ResourceId'
+          operator: 'GreaterThanOrEqual'
+          threshold: 1
+          failingPeriods: { numberOfEvaluationPeriods: 1, minFailingPeriodsToAlert: 1 }
+        }
+      ]
+    }
+    actions: actions
+  }
+}
+
+// FSLogix service disabled (EventID 60)
+resource alertFSLogixServiceDisabled 'Microsoft.Insights/scheduledQueryRules@2022-06-15' = if (enableFslogixAlerts) {
+  name: '${alertNamePrefix}-HP-VM-FSLgxProf-SvcDisabled-${hostPoolName}'
+  location: location
+  properties: {
+    displayName: '${alertNamePrefix} - FSLogix Service Disabled (${hostPoolName})'
+    description: '${descriptionHeader}FSLogix Event ID 60: the FSLogix Profile service is disabled on a session host in ${hostPoolName}. Re-enable and start the FSLogix service immediately.'
+    severity: 1
+    enabled: true
+    evaluationFrequency: 'PT5M'
+    windowSize: 'P1D'
+    scopes: [logAnalyticsWorkspaceResourceId]
+    autoMitigate: autoResolveAlert
+    criteria: {
+      allOf: [
+        {
+          query: '''
+Event
+| where EventLog == "Microsoft-FSLogix-Apps/Admin"
+| where EventLevelName == "Warning"
+| where EventID == 60
+| parse _ResourceId with "/subscriptions/" subscription "/resourcegroups/" ResourceGroup "/providers/microsoft.compute/virtualmachines/" ComputerName
+| extend ComputerName=tolower(ComputerName)
+| project ComputerName, RenderedDescription, subscription, ResourceGroup, TimeGenerated
+| join kind=leftouter (
+    WVDAgentHealthStatus
+    | where _ResourceId contains '${hostPoolName}'
+    | parse _ResourceId with "/subscriptions/" subscriptionAgentHealth "/resourcegroups/" ResourceGroupAgentHealth "/providers/microsoft.desktopvirtualization/hostpools/" HostPool
+    | parse SessionHostResourceId with "/subscriptions/" VMsubscription "/resourceGroups/" VMresourceGroup "/providers/Microsoft.Compute/virtualMachines/" ComputerName
+    | extend ComputerName=tolower(ComputerName)
+    | summarize arg_max(TimeGenerated, *) by ComputerName
+    | project VMresourceGroup, ComputerName, HostPool
+) on ComputerName
+'''
+          timeAggregation: 'Count'
+          dimensions: [
+            { name: 'ComputerName', operator: 'Include', values: ['*'] }
+            { name: 'RenderedDescription', operator: 'Include', values: ['*'] }
+            { name: 'VMresourceGroup', operator: 'Include', values: ['*'] }
+            { name: 'HostPool', operator: 'Include', values: ['*'] }
+          ]
+          resourceIdColumn: '_ResourceId'
+          operator: 'GreaterThanOrEqual'
+          threshold: 1
+          failingPeriods: { numberOfEvaluationPeriods: 1, minFailingPeriodsToAlert: 1 }
+        }
+      ]
+    }
+    actions: actions
+  }
+}
+
+// FSLogix disk compaction failed (EventID 62 or 63)
+resource alertFSLogixDiskCompaction 'Microsoft.Insights/scheduledQueryRules@2022-06-15' = if (enableFslogixAlerts) {
+  name: '${alertNamePrefix}-HP-VM-FSLgxProf-DskCmpFail-${hostPoolName}'
+  location: location
+  properties: {
+    displayName: '${alertNamePrefix} - FSLogix Profile Disk Compaction Failed (${hostPoolName})'
+    description: '${descriptionHeader}FSLogix Event ID 62 or 63: profile disk compaction failed on a session host in ${hostPoolName}. The disk was marked for compaction but the operation failed.'
+    severity: 2
+    enabled: true
+    evaluationFrequency: 'PT5M'
+    windowSize: 'P1D'
+    scopes: [logAnalyticsWorkspaceResourceId]
+    autoMitigate: autoResolveAlert
+    criteria: {
+      allOf: [
+        {
+          query: '''
+Event
+| where EventLog == "Microsoft-FSLogix-Apps/Admin"
+| where EventLevelName == "Error"
+| where EventID == 62 or EventID == 63
+| parse _ResourceId with "/subscriptions/" subscription "/resourcegroups/" ResourceGroup "/providers/microsoft.compute/virtualmachines/" ComputerName
+| extend ComputerName=tolower(ComputerName)
+| project ComputerName, RenderedDescription, subscription, ResourceGroup, TimeGenerated
+| join kind=leftouter (
+    WVDAgentHealthStatus
+    | where _ResourceId contains '${hostPoolName}'
+    | parse _ResourceId with "/subscriptions/" subscriptionAgentHealth "/resourcegroups/" ResourceGroupAgentHealth "/providers/microsoft.desktopvirtualization/hostpools/" HostPool
+    | parse SessionHostResourceId with "/subscriptions/" VMsubscription "/resourceGroups/" VMresourceGroup "/providers/Microsoft.Compute/virtualMachines/" ComputerName
+    | extend ComputerName=tolower(ComputerName)
+    | summarize arg_max(TimeGenerated, *) by ComputerName
+    | project VMresourceGroup, ComputerName, HostPool
+) on ComputerName
+'''
+          timeAggregation: 'Count'
+          dimensions: [
+            { name: 'ComputerName', operator: 'Include', values: ['*'] }
+            { name: 'RenderedDescription', operator: 'Include', values: ['*'] }
+            { name: 'VMresourceGroup', operator: 'Include', values: ['*'] }
+            { name: 'HostPool', operator: 'Include', values: ['*'] }
+          ]
+          resourceIdColumn: '_ResourceId'
+          operator: 'GreaterThanOrEqual'
+          threshold: 1
+          failingPeriods: { numberOfEvaluationPeriods: 1, minFailingPeriodsToAlert: 1 }
+        }
+      ]
+    }
+    actions: actions
+  }
+}
+
+// FSLogix profile disk in use by another VM (EventID 51)
+resource alertFSLogixDiskInUse 'Microsoft.Insights/scheduledQueryRules@2022-06-15' = if (enableFslogixAlerts) {
+  name: '${alertNamePrefix}-HP-VM-FSLgxProf-DskInUse-${hostPoolName}'
+  location: location
+  properties: {
+    displayName: '${alertNamePrefix} - FSLogix Profile Disk In Use by Another VM (${hostPoolName})'
+    description: '${descriptionHeader}FSLogix Event ID 51: a profile VHD is already attached to another VM in ${hostPoolName}. Ensure the user is not connected to multiple host pools sharing the same profile.'
+    severity: 2
+    enabled: true
+    evaluationFrequency: 'PT5M'
+    windowSize: 'P1D'
+    scopes: [logAnalyticsWorkspaceResourceId]
+    autoMitigate: autoResolveAlert
+    criteria: {
+      allOf: [
+        {
+          query: '''
+Event
+| where EventLog == "Microsoft-FSLogix-Apps/Operational"
+| where EventLevelName == "Warning"
+| where EventID == 51
+| parse _ResourceId with "/subscriptions/" subscription "/resourcegroups/" ResourceGroup "/providers/microsoft.compute/virtualmachines/" ComputerName
+| extend ComputerName=tolower(ComputerName)
+| project ComputerName, RenderedDescription, subscription, ResourceGroup, TimeGenerated
+| join kind=leftouter (
+    WVDAgentHealthStatus
+    | where _ResourceId contains '${hostPoolName}'
+    | parse _ResourceId with "/subscriptions/" subscriptionAgentHealth "/resourcegroups/" ResourceGroupAgentHealth "/providers/microsoft.desktopvirtualization/hostpools/" HostPool
+    | parse SessionHostResourceId with "/subscriptions/" VMsubscription "/resourceGroups/" VMresourceGroup "/providers/Microsoft.Compute/virtualMachines/" ComputerName
+    | extend ComputerName=tolower(ComputerName)
+    | summarize arg_max(TimeGenerated, *) by ComputerName
+    | project VMresourceGroup, ComputerName, HostPool
+) on ComputerName
+'''
+          timeAggregation: 'Count'
+          dimensions: [
+            { name: 'ComputerName', operator: 'Include', values: ['*'] }
+            { name: 'RenderedDescription', operator: 'Include', values: ['*'] }
+            { name: 'VMresourceGroup', operator: 'Include', values: ['*'] }
+            { name: 'HostPool', operator: 'Include', values: ['*'] }
+          ]
+          resourceIdColumn: '_ResourceId'
+          operator: 'GreaterThanOrEqual'
+          threshold: 1
+          failingPeriods: { numberOfEvaluationPeriods: 1, minFailingPeriodsToAlert: 1 }
+        }
+      ]
+    }
+    actions: actions
+  }
+}
+
+// FSLogix corrupted / temp profile (EventID 28)
+// Uses a two-step lookup to correlate the error with a storage account path
+// (EventID 28 itself does not include the path, so we find a nearby event that does),
+// then joins with WVDConnections to identify the affected user.
+resource alertFSLogixCorruptedProfile 'Microsoft.Insights/scheduledQueryRules@2022-06-15' = if (enableFslogixAlerts) {
+  name: '${alertNamePrefix}-HP-VM-FSLgxProf-Corrupt-${hostPoolName}'
+  location: location
+  properties: {
+    displayName: '${alertNamePrefix} - FSLogix Corrupted / Temp Profile (${hostPoolName})'
+    description: '${descriptionHeader}FSLogix Event ID 28 in ${hostPoolName}: a user profile VHD is corrupted or could not be mounted and the user was loaded into a temporary profile. Data written during this session will be lost. Investigate and repair the profile VHD.'
+    severity: 2
+    enabled: true
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT1H'
+    overrideQueryTimeRange: 'P2D'
+    scopes: [logAnalyticsWorkspaceResourceId]
+    autoMitigate: autoResolveAlert
+    criteria: {
+      allOf: [
+        {
+          query: '''
+let fslogixErrors =
+    Event
+    | where Source == "Microsoft-FSLogix-Apps"
+    | where EventID == 28
+    | extend ProfileID = tostring(extract(@"Username:\s*([^\s]+)", 1, RenderedDescription))
+    | project EventTime = TimeGenerated, Computer, ProfileID, EventID, RenderedDescription;
+let storageLookup =
+    Event
+    | where Source == "Microsoft-FSLogix-Apps"
+    | where RenderedDescription has ".file.core."
+    | extend StorageAccount = extract(@"\\\\([^\\]+\.file\.core\.(windows|usgovcloudapi)\.net)", 1, RenderedDescription)
+    | where isnotempty(StorageAccount)
+    | project PathTime = TimeGenerated, Computer, StorageAccount;
+fslogixErrors
+| join kind=leftouter (storageLookup) on Computer
+| extend PathDiff = abs(datetime_diff('minute', EventTime, PathTime))
+| where PathDiff <= 60
+| join kind=inner (
+    WVDConnections
+    | where _ResourceId contains '${hostPoolName}'
+    | where State == "Connected"
+    | project ConnTime = TimeGenerated, UserName, SessionHostName, ResourceId = _ResourceId
+) on $left.Computer == $right.SessionHostName
+| extend TimeDiff = abs(datetime_diff('minute', EventTime, ConnTime))
+| where TimeDiff <= 30
+| summarize arg_min(TimeDiff, *) by EventTime, Computer
+| project
+    EventTime,
+    UserName,
+    ProfileID,
+    SessionHostName = Computer,
+    StorageAccount,
+    EventID,
+    RenderedDescription,
+    ResourceId
+| order by EventTime desc
+'''
+          timeAggregation: 'Count'
+          dimensions: [
+            { name: 'UserName',        operator: 'Include', values: ['*'] }
+            { name: 'ProfileID',       operator: 'Include', values: ['*'] }
+            { name: 'SessionHostName', operator: 'Include', values: ['*'] }
+            { name: 'StorageAccount',  operator: 'Include', values: ['*'] }
+          ]
+          resourceIdColumn: 'ResourceId'
+          operator: 'GreaterThanOrEqual'
+          threshold: 1
+          failingPeriods: { numberOfEvaluationPeriods: 1, minFailingPeriodsToAlert: 1 }
+        }
+      ]
+    }
+    actions: actions
+  }
+}
+
+// FSLogix VHD compaction pre-check failure (EventID 58, 61)
+// EventID 58: VHD compaction aborted due to insufficient free space to perform the operation.
+// EventID 61: VHD compaction aborted because the VHD is currently in use.
+// These are pre-conditions that will prevent compaction from completing and can mask a disk space problem.
+// EventIDs 60, 62, 63 have dedicated alerts; this rule covers the earlier-stage pre-check failures.
+resource alertFSLogixCompactionPrecheck 'Microsoft.Insights/scheduledQueryRules@2022-06-15' = if (enableFslogixAlerts) {
+  name: '${alertNamePrefix}-HP-VM-FSLgxProf-CmpctPre-${hostPoolName}'
+  location: location
+  properties: {
+    displayName: '${alertNamePrefix} - FSLogix VHD Compaction Pre-Check Failure (${hostPoolName})'
+    description: '${descriptionHeader}FSLogix Event ID 58 or 61 in ${hostPoolName}: VHD disk compaction was aborted before starting, either because the host disk lacks free space for the operation (58) or the VHD is in use (61). Profile VHDs will grow unbounded until compaction can complete.'
+    severity: 2
+    enabled: true
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT1H'
+    overrideQueryTimeRange: 'P2D'
+    scopes: [logAnalyticsWorkspaceResourceId]
+    autoMitigate: autoResolveAlert
+    criteria: {
+      allOf: [
+        {
+          query: '''
+let fslogixErrors =
+    Event
+    | where Source == "Microsoft-FSLogix-Apps"
+    | where EventID in (58, 61)
+    | extend
+        StorageAccount = extract(@"\\\\([^\\]+\.file\.core\.(windows|usgovcloudapi)\.net)", 1, RenderedDescription),
+        ProfileRaw     = extract(@"profilecontainers\\([^\\]+)", 1, RenderedDescription)
+    | extend ProfileID = tostring(split(ProfileRaw, "_")[0])
+    | project EventTime = TimeGenerated, Computer, ProfileID, StorageAccount, EventID, RenderedDescription;
+fslogixErrors
+| join kind=inner (
+    WVDConnections
+    | where _ResourceId contains '${hostPoolName}'
+    | where State == "Connected"
+    | project ConnTime = TimeGenerated, UserName, SessionHostName, ResourceId = _ResourceId
+) on $left.Computer == $right.SessionHostName
+| extend TimeDiff = abs(datetime_diff('minute', EventTime, ConnTime))
+| where TimeDiff <= 30
+| summarize arg_min(TimeDiff, *) by EventTime, Computer
+| project
+    EventTime,
+    UserName,
+    ProfileID,
+    SessionHostName = Computer,
+    StorageAccount,
+    EventID,
+    RenderedDescription,
+    ResourceId
+| order by EventTime desc
+'''
+          timeAggregation: 'Count'
+          dimensions: [
+            { name: 'UserName',        operator: 'Include', values: ['*'] }
+            { name: 'ProfileID',       operator: 'Include', values: ['*'] }
+            { name: 'SessionHostName', operator: 'Include', values: ['*'] }
+            { name: 'StorageAccount',  operator: 'Include', values: ['*'] }
+            { name: 'EventID',         operator: 'Include', values: ['*'] }
+          ]
+          resourceIdColumn: 'ResourceId'
+          operator: 'GreaterThanOrEqual'
+          threshold: 1
+          failingPeriods: { numberOfEvaluationPeriods: 1, minFailingPeriodsToAlert: 1 }
+        }
+      ]
+    }
+    actions: actions
+  }
+}
+
+// Slow session logon - time from connection start to productive desktop > 2 minutes
+// Uses WVDCheckpoints ShellReady / RdpShellAppExecuted to measure full logon time
+// (includes Windows logon, profile load, GPO processing, startup scripts).
+// Fires at Sev 3 as an early warning; repeated occurrences indicate profile bloat, GPO issues,
+// or storage latency on the FSLogix share.
+resource alertSlowSessionLogon 'Microsoft.Insights/scheduledQueryRules@2022-06-15' = if (enableConnectionAlerts) {
+  name: '${alertNamePrefix}-HP-Usr-SlowLogon-${hostPoolName}'
+  location: location
+  properties: {
+    displayName: '${alertNamePrefix} - Slow Session Logon > 2 Minutes (${hostPoolName})'
+    description: '${descriptionHeader}A user in ${hostPoolName} took more than 2 minutes from connection start to productive desktop. Common causes: FSLogix profile bloat, GPO processing delay, slow storage, or startup scripts. Review FSLogix profile sizes and storage latency.'
+    severity: 3
+    enabled: true
+    evaluationFrequency: 'PT15M'
+    windowSize: 'PT30M'
+    overrideQueryTimeRange: 'P2D'
+    scopes: [logAnalyticsWorkspaceResourceId]
+    autoMitigate: autoResolveAlert
+    criteria: {
+      allOf: [
+        {
+          query: '''
+WVDConnections
+| where TimeGenerated > ago(30m)
+| where _ResourceId contains '${hostPoolName}'
+| where State == "Started"
+| project CorrelationId, UserName, SessionHostName, StartTime = TimeGenerated, ResourceId = _ResourceId
+| join kind=inner (
+    WVDCheckpoints
+    | where _ResourceId contains '${hostPoolName}'
+    | where Name =~ "ShellReady"
+        or (Name =~ "LaunchExecutable" and tostring(Parameters.connectionStage) == "RdpShellAppExecuted")
+        or Name =~ "RdpShellAppExecuted"
+    | summarize ShellReadyTime = min(TimeGenerated) by CorrelationId
+) on CorrelationId
+| extend LogonSeconds = datetime_diff('second', ShellReadyTime, StartTime)
+| where LogonSeconds > 120
+| project
+    StartTime,
+    UserName,
+    SessionHostName,
+    LogonSeconds,
+    LogonMinutes = round(LogonSeconds / 60.0, 1),
+    ResourceId
+| order by LogonSeconds desc
+'''
+          timeAggregation: 'Count'
+          dimensions: [
+            { name: 'UserName',        operator: 'Include', values: ['*'] }
+            { name: 'SessionHostName', operator: 'Include', values: ['*'] }
+            { name: 'LogonMinutes',    operator: 'Include', values: ['*'] }
+          ]
+          resourceIdColumn: 'ResourceId'
+          operator: 'GreaterThanOrEqual'
+          threshold: 1
+          failingPeriods: { numberOfEvaluationPeriods: 1, minFailingPeriodsToAlert: 1 }
+        }
+      ]
+    }
+    actions: actions
+  }
+}

--- a/deployments/add-ons/avdAlerts/modules/roleAssignment.bicep
+++ b/deployments/add-ons/avdAlerts/modules/roleAssignment.bicep
@@ -1,0 +1,32 @@
+// Role Assignment Module
+// Resource-group-scoped role assignment helper used by the AVD Alerts add-on
+// to grant the Automation Account managed identity the necessary permissions.
+
+// ========== //
+// Parameters //
+// ========== //
+
+@description('Required. Principal ID (object ID) of the managed identity.')
+param principalId string
+
+@description('Required. GUID of the built-in role definition to assign.')
+param roleDefinitionId string
+
+@description('Required. Name of the resource group (used as part of the role assignment name to ensure uniqueness).')
+param resourceGroupName string
+
+@description('Required. Additional suffix to disambiguate the role assignment when the same role is assigned multiple times in different resource groups.')
+param nameSuffix string
+
+// ========== //
+// Resources  //
+// ========== //
+
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(resourceGroup().id, principalId, roleDefinitionId, resourceGroupName, nameSuffix)
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', roleDefinitionId)
+    principalId: principalId
+    principalType: 'ServicePrincipal'
+  }
+}

--- a/deployments/add-ons/avdAlerts/modules/serviceHealthAlerts.bicep
+++ b/deployments/add-ons/avdAlerts/modules/serviceHealthAlerts.bicep
@@ -1,0 +1,156 @@
+// AVD Alerts Add-On - Service Health Alert Rules Module
+// Deploys Azure Service Health activity log alert rules scoped to the current subscription.
+//
+// Alert rules:
+//   - Service Issue (active incident affecting Azure services)  (Sev 0)
+//   - Planned Maintenance                                       (Sev 2)
+//   - Health Advisory (informational / action required)        (Sev 3)
+//   - Security Advisory                                        (Sev 0)
+
+// ========== //
+// Parameters //
+// ========== //
+
+@description('Required. Resource ID of the Action Group for notifications.')
+param actionGroupResourceId string
+
+@description('Optional. Prefix prepended to all alert names.')
+param alertNamePrefix string = 'AVD'
+
+@description('Optional. When false, Azure Service Health activity log alert rules are not deployed.')
+param enableServiceHealthAlerts bool = true
+
+// ========== //
+// Variables  //
+// ========== //
+
+var subscriptionResourceId = subscription().id
+var descriptionHeader      = 'FederalAVD - Automated Alert\n'
+
+var alertActions = {
+  actionGroups: [
+    {
+      actionGroupId: actionGroupResourceId
+    }
+  ]
+}
+
+// ========== //
+// Resources  //
+// ========== //
+
+// Service Issue (active incident)
+resource alertServiceIssue 'Microsoft.Insights/activityLogAlerts@2020-10-01' = if (enableServiceHealthAlerts) {
+  name: '${alertNamePrefix}-SvcHealth-ServiceIssue'
+  location: 'global'
+  properties: {
+    description: '${descriptionHeader}An active Azure service incident has been detected that may be affecting AVD components in this subscription.'
+    enabled: true
+    scopes: [subscriptionResourceId]
+    condition: {
+      allOf: [
+        {
+          field: 'category'
+          equals: 'ServiceHealth'
+        }
+        {
+          anyOf: [
+            {
+              field: 'properties.incidentType'
+              equals: 'Incident'
+            }
+          ]
+        }
+      ]
+    }
+    actions: alertActions
+  }
+}
+
+// Planned Maintenance
+resource alertPlannedMaintenance 'Microsoft.Insights/activityLogAlerts@2020-10-01' = if (enableServiceHealthAlerts) {
+  name: '${alertNamePrefix}-SvcHealth-PlannedMaintenance'
+  location: 'global'
+  properties: {
+    description: '${descriptionHeader}Planned Azure maintenance has been scheduled that may affect AVD components in this subscription.'
+    enabled: true
+    scopes: [subscriptionResourceId]
+    condition: {
+      allOf: [
+        {
+          field: 'category'
+          equals: 'ServiceHealth'
+        }
+        {
+          anyOf: [
+            {
+              field: 'properties.incidentType'
+              equals: 'Maintenance'
+            }
+          ]
+        }
+      ]
+    }
+    actions: alertActions
+  }
+}
+
+// Health Advisory (informational or action required)
+resource alertHealthAdvisory 'Microsoft.Insights/activityLogAlerts@2020-10-01' = if (enableServiceHealthAlerts) {
+  name: '${alertNamePrefix}-SvcHealth-HealthAdvisory'
+  location: 'global'
+  properties: {
+    description: '${descriptionHeader}An Azure Health Advisory has been issued for services in this subscription. Review to determine if action is required for your AVD environment.'
+    enabled: true
+    scopes: [subscriptionResourceId]
+    condition: {
+      allOf: [
+        {
+          field: 'category'
+          equals: 'ServiceHealth'
+        }
+        {
+          anyOf: [
+            {
+              field: 'properties.incidentType'
+              equals: 'Informational'
+            }
+            {
+              field: 'properties.incidentType'
+              equals: 'ActionRequired'
+            }
+          ]
+        }
+      ]
+    }
+    actions: alertActions
+  }
+}
+
+// Security Advisory
+resource alertSecurity 'Microsoft.Insights/activityLogAlerts@2020-10-01' = if (enableServiceHealthAlerts) {
+  name: '${alertNamePrefix}-SvcHealth-Security'
+  location: 'global'
+  properties: {
+    description: '${descriptionHeader}An Azure Security Advisory has been issued for services in this subscription. Review immediately for potential security impact on your AVD environment.'
+    enabled: true
+    scopes: [subscriptionResourceId]
+    condition: {
+      allOf: [
+        {
+          field: 'category'
+          equals: 'ServiceHealth'
+        }
+        {
+          anyOf: [
+            {
+              field: 'properties.incidentType'
+              equals: 'Security'
+            }
+          ]
+        }
+      ]
+    }
+    actions: alertActions
+  }
+}

--- a/deployments/add-ons/avdAlerts/modules/storageAlerts.bicep
+++ b/deployments/add-ons/avdAlerts/modules/storageAlerts.bicep
@@ -1,0 +1,374 @@
+// AVD Alerts Add-On - Storage Alert Rules Module
+// Deploys metric-based and log-based alert rules for an Azure Files storage account
+// used for FSLogix profile storage.
+//
+// Metric alerts (per storage account):
+//   - SuccessServerLatency > 50ms  (Sev 2)
+//   - SuccessServerLatency > 100ms (Sev 1)
+//   - SuccessE2ELatency > 50ms     (Sev 2)
+//   - SuccessE2ELatency > 100ms    (Sev 1)
+//   - Availability < 99%           (Sev 1)
+//
+// File share metric alerts (per file service):
+//   - Throttling (Transactions with throttling response types)  (Sev 2)
+//
+// Log-based alerts (storage space - require Automation Account runbook data):
+//   - Azure Files share <= 15% remaining  (Sev 2)
+//   - Azure Files share <=  5% remaining  (Sev 1)
+//
+// NOTE: The log-based storage space alerts are created once per deployment (not per
+//       storage account) because the runbook outputs all shares to a single job stream.
+//       Pass createStorageLogAlerts = true only on the first storage account in the array.
+
+// ========== //
+// Parameters //
+// ========== //
+
+@description('Required. Resource ID of the storage account to monitor.')
+param storageAccountResourceId string
+
+@description('Required. Resource ID of the Action Group for notifications.')
+param actionGroupResourceId string
+
+@description('Optional. Prefix prepended to all alert names.')
+param alertNamePrefix string = 'AVD'
+
+@description('Optional. Whether alert rules auto-resolve when the condition clears.')
+param autoResolveAlert bool = true
+
+@description('Optional. Azure region for the alert rule resources.')
+param location string
+
+@description('Optional. Log Analytics Workspace resource ID. Required when createStorageLogAlerts is true.')
+param logAnalyticsWorkspaceResourceId string = ''
+
+@description('Optional. Set true to also create the log-based storage space alerts (driven by the AA runbook). Only set true for one storage account per deployment to avoid duplicate alert rules.')
+param createStorageLogAlerts bool = false
+
+@description('Optional. When false, storage server and end-to-end latency alert rules are not deployed.')
+param enableStorageLatencyAlerts bool = true
+
+@description('Optional. When false, storage account availability alert rules are not deployed.')
+param enableStorageAvailabilityAlerts bool = true
+
+@description('Optional. When false, file share throttling alert rules are not deployed.')
+param enableStorageThrottlingAlerts bool = true
+
+// ========== //
+// Variables  //
+// ========== //
+
+var storageAccountName  = last(split(storageAccountResourceId, '/'))
+var fileServiceResourceId = '${storageAccountResourceId}/fileServices/default'
+var descriptionHeader   = 'FederalAVD - Automated Alert\n'
+
+var metricActions = [
+  {
+    actionGroupId: actionGroupResourceId
+  }
+]
+
+// ========== //
+// Resources  //
+// ========== //
+
+// SuccessServerLatency > 50ms (Sev 2)
+resource alertServerLatency50 'Microsoft.Insights/metricAlerts@2018-03-01' = if (enableStorageLatencyAlerts) {
+  name: '${alertNamePrefix}-StorAcct-Ovr50msLatncy-${storageAccountName}'
+  location: 'global'
+  properties: {
+    description: '${descriptionHeader}Storage account server latency exceeded 50ms average. This may indicate performance degradation for FSLogix user profiles. Storage account: ${storageAccountName}.'
+    severity: 2
+    enabled: true
+    scopes: [storageAccountResourceId]
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT15M'
+    targetResourceType: 'Microsoft.Storage/storageAccounts'
+    criteria: {
+      'odata.type': 'Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria'
+      allOf: [
+        {
+          name: 'Metric1'
+          metricName: 'SuccessServerLatency'
+          operator: 'GreaterThan'
+          threshold: 50
+          timeAggregation: 'Average'
+          criterionType: 'StaticThresholdCriterion'
+        }
+      ]
+    }
+    autoMitigate: autoResolveAlert
+    actions: metricActions
+  }
+}
+
+// SuccessServerLatency > 100ms (Sev 1)
+resource alertServerLatency100 'Microsoft.Insights/metricAlerts@2018-03-01' = if (enableStorageLatencyAlerts) {
+  name: '${alertNamePrefix}-StorAcct-Ovr100msLatncy-${storageAccountName}'
+  location: 'global'
+  properties: {
+    description: '${descriptionHeader}Storage account server latency exceeded 100ms average. Users may experience slow profile loading or application performance. Storage account: ${storageAccountName}.'
+    severity: 1
+    enabled: true
+    scopes: [storageAccountResourceId]
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT15M'
+    targetResourceType: 'Microsoft.Storage/storageAccounts'
+    criteria: {
+      'odata.type': 'Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria'
+      allOf: [
+        {
+          name: 'Metric1'
+          metricName: 'SuccessServerLatency'
+          operator: 'GreaterThan'
+          threshold: 100
+          timeAggregation: 'Average'
+          criterionType: 'StaticThresholdCriterion'
+        }
+      ]
+    }
+    autoMitigate: autoResolveAlert
+    actions: metricActions
+  }
+}
+
+// SuccessE2ELatency > 50ms (Sev 2)
+resource alertE2ELatency50 'Microsoft.Insights/metricAlerts@2018-03-01' = if (enableStorageLatencyAlerts) {
+  name: '${alertNamePrefix}-StorAcct-Ovr50msE2ELatncy-${storageAccountName}'
+  location: 'global'
+  properties: {
+    description: '${descriptionHeader}End-to-end latency from session host to storage exceeded 50ms average. This includes network latency and may indicate network path issues. Storage account: ${storageAccountName}.'
+    severity: 2
+    enabled: true
+    scopes: [storageAccountResourceId]
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT15M'
+    targetResourceType: 'Microsoft.Storage/storageAccounts'
+    criteria: {
+      'odata.type': 'Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria'
+      allOf: [
+        {
+          name: 'Metric1'
+          metricName: 'SuccessE2ELatency'
+          operator: 'GreaterThan'
+          threshold: 50
+          timeAggregation: 'Average'
+          criterionType: 'StaticThresholdCriterion'
+        }
+      ]
+    }
+    autoMitigate: autoResolveAlert
+    actions: metricActions
+  }
+}
+
+// SuccessE2ELatency > 100ms (Sev 1)
+resource alertE2ELatency100 'Microsoft.Insights/metricAlerts@2018-03-01' = if (enableStorageLatencyAlerts) {
+  name: '${alertNamePrefix}-StorAcct-Ovr100msE2ELatncy-${storageAccountName}'
+  location: 'global'
+  properties: {
+    description: '${descriptionHeader}End-to-end latency from session host to storage exceeded 100ms average. Users are likely experiencing degraded profile performance. Storage account: ${storageAccountName}.'
+    severity: 1
+    enabled: true
+    scopes: [storageAccountResourceId]
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT15M'
+    targetResourceType: 'Microsoft.Storage/storageAccounts'
+    criteria: {
+      'odata.type': 'Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria'
+      allOf: [
+        {
+          name: 'Metric1'
+          metricName: 'SuccessE2ELatency'
+          operator: 'GreaterThan'
+          threshold: 100
+          timeAggregation: 'Average'
+          criterionType: 'StaticThresholdCriterion'
+        }
+      ]
+    }
+    autoMitigate: autoResolveAlert
+    actions: metricActions
+  }
+}
+
+// Availability < 99% (Sev 1)
+resource alertAvailability 'Microsoft.Insights/metricAlerts@2018-03-01' = if (enableStorageAvailabilityAlerts) {
+  name: '${alertNamePrefix}-StorAcct-AvailBlw99Prcnt-${storageAccountName}'
+  location: 'global'
+  properties: {
+    description: '${descriptionHeader}Storage account availability dropped below 99%. FSLogix user profiles and MSIX App Attach may be unavailable. Storage account: ${storageAccountName}.'
+    severity: 1
+    enabled: true
+    scopes: [storageAccountResourceId]
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT5M'
+    targetResourceType: 'Microsoft.Storage/storageAccounts'
+    criteria: {
+      'odata.type': 'Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria'
+      allOf: [
+        {
+          name: 'Metric1'
+          metricName: 'Availability'
+          operator: 'LessThan'
+          threshold: 99
+          timeAggregation: 'Average'
+          criterionType: 'StaticThresholdCriterion'
+        }
+      ]
+    }
+    autoMitigate: autoResolveAlert
+    actions: metricActions
+  }
+}
+
+// File share throttling - IOPS limit reached (Sev 2)
+resource alertFileShareThrottling 'Microsoft.Insights/metricAlerts@2018-03-01' = if (enableStorageThrottlingAlerts) {
+  name: '${alertNamePrefix}-StorAcct-PossThrottle-${storageAccountName}'
+  location: 'global'
+  properties: {
+    description: '${descriptionHeader}Azure Files share is being throttled due to high IOPS. Users may experience slow profile operations. Consider upgrading to a higher tier or increasing the provisioned capacity. Storage account: ${storageAccountName}.'
+    severity: 2
+    enabled: true
+    scopes: [fileServiceResourceId]
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT15M'
+    targetResourceType: 'Microsoft.Storage/storageAccounts/fileServices'
+    criteria: {
+      'odata.type': 'Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria'
+      allOf: [
+        {
+          name: 'Metric1'
+          metricName: 'Transactions'
+          operator: 'GreaterThanOrEqual'
+          threshold: 1
+          timeAggregation: 'Total'
+          criterionType: 'StaticThresholdCriterion'
+          dimensions: [
+            {
+              name: 'ResponseType'
+              operator: 'Include'
+              values: [
+                'SuccessWithThrottling'
+                'SuccessWithShareEgressThrottling'
+                'SuccessWithShareIngressThrottling'
+                'SuccessWithShareIopsThrottling'
+                'ClientShareEgressThrottlingError'
+                'ClientShareIngressThrottlingError'
+                'ClientShareIopsThrottlingError'
+              ]
+            }
+          ]
+        }
+      ]
+    }
+    autoMitigate: autoResolveAlert
+    actions: metricActions
+  }
+}
+
+// ------------------------------------
+// Log-based storage space alerts
+// Driven by AvdStorageLogData runbook output -> Log Analytics
+// Only create when createStorageLogAlerts is true
+// ------------------------------------
+
+// Azure Files share <= 15% free space (Sev 2)
+resource alertStorageLowSpace15 'Microsoft.Insights/scheduledQueryRules@2022-06-15' = if (createStorageLogAlerts) {
+  name: '${alertNamePrefix}-StorAzFile-LowSpc15Prcnt'
+  location: location
+  properties: {
+    displayName: '${alertNamePrefix} - Azure Files Share Low Space - 15% Remaining'
+    description: '${descriptionHeader}An Azure Files share used for FSLogix profiles has 15% or less free space. Review share quota and used space, and increase quota to avoid profile load failures.'
+    severity: 2
+    enabled: true
+    evaluationFrequency: 'PT10M'
+    windowSize: 'PT1H'
+    overrideQueryTimeRange: 'P2D'
+    scopes: [logAnalyticsWorkspaceResourceId]
+    autoMitigate: autoResolveAlert
+    criteria: {
+      allOf: [
+        {
+          query: '''
+AzureDiagnostics
+| where Category has "JobStreams" and StreamType_s == "Output" and RunbookName_s == "AvdStorageLogData"
+| where split(ResultDescription, ',')[1] != ""
+| extend StorageAccount=tostring(split(ResultDescription, ',')[1])
+| extend ResourceGroup=tostring(split(ResultDescription, ',')[2])
+| extend Share=tostring(split(ResultDescription, ',')[3])
+| extend GBShareQuota=split(ResultDescription, ',')[4]
+| extend GBUsed=split(ResultDescription, ',')[5]
+| extend PercentAvailable=round(toreal(split(ResultDescription, ',')[6]))
+| extend ResourceId=tostring(split(ResultDescription, ',')[7])
+| summarize arg_max(TimeGenerated, *) by Share
+| where PercentAvailable <= 15.00
+| project TimeGenerated, ResourceId, StorageAccount, Share, PercentAvailable
+'''
+          timeAggregation: 'Count'
+          dimensions: [
+            { name: 'StorageAccount', operator: 'Include', values: ['*'] }
+            { name: 'Share', operator: 'Include', values: ['*'] }
+          ]
+          resourceIdColumn: 'ResourceId'
+          operator: 'GreaterThanOrEqual'
+          threshold: 1
+          failingPeriods: { numberOfEvaluationPeriods: 1, minFailingPeriodsToAlert: 1 }
+        }
+      ]
+    }
+    actions: {
+      actionGroups: [actionGroupResourceId]
+    }
+  }
+}
+
+// Azure Files share <= 5% free space (Sev 1)
+resource alertStorageLowSpace5 'Microsoft.Insights/scheduledQueryRules@2022-06-15' = if (createStorageLogAlerts) {
+  name: '${alertNamePrefix}-StorAzFile-LowSpc5Prcnt'
+  location: location
+  properties: {
+    displayName: '${alertNamePrefix} - Azure Files Share Low Space - 5% Remaining'
+    description: '${descriptionHeader}CRITICAL: An Azure Files share used for FSLogix profiles has 5% or less free space. New profile loads will fail when the share fills up. Increase quota immediately.'
+    severity: 1
+    enabled: true
+    evaluationFrequency: 'PT10M'
+    windowSize: 'PT1H'
+    overrideQueryTimeRange: 'P2D'
+    scopes: [logAnalyticsWorkspaceResourceId]
+    autoMitigate: autoResolveAlert
+    criteria: {
+      allOf: [
+        {
+          query: '''
+AzureDiagnostics
+| where Category has "JobStreams" and StreamType_s == "Output" and RunbookName_s == "AvdStorageLogData"
+| where split(ResultDescription, ',')[1] != ""
+| extend StorageAccount=tostring(split(ResultDescription, ',')[1])
+| extend ResourceGroup=tostring(split(ResultDescription, ',')[2])
+| extend Share=tostring(split(ResultDescription, ',')[3])
+| extend GBShareQuota=split(ResultDescription, ',')[4]
+| extend GBUsed=split(ResultDescription, ',')[5]
+| extend PercentAvailable=round(toreal(split(ResultDescription, ',')[6]))
+| extend ResourceId=tostring(split(ResultDescription, ',')[7])
+| summarize arg_max(TimeGenerated, *) by Share
+| where PercentAvailable <= 5.00
+| project TimeGenerated, ResourceId, StorageAccount, Share, PercentAvailable
+'''
+          timeAggregation: 'Count'
+          dimensions: [
+            { name: 'StorageAccount', operator: 'Include', values: ['*'] }
+            { name: 'Share', operator: 'Include', values: ['*'] }
+          ]
+          resourceIdColumn: 'ResourceId'
+          operator: 'GreaterThanOrEqual'
+          threshold: 1
+          failingPeriods: { numberOfEvaluationPeriods: 1, minFailingPeriodsToAlert: 1 }
+        }
+      ]
+    }
+    actions: {
+      actionGroups: [actionGroupResourceId]
+    }
+  }
+}

--- a/deployments/add-ons/avdAlerts/modules/vmMetricAlerts.bicep
+++ b/deployments/add-ons/avdAlerts/modules/vmMetricAlerts.bicep
@@ -1,0 +1,264 @@
+// AVD Alerts Add-On - VM Metric Alert Rules Module
+// Deploys multi-resource metric alert rules scoped to a VM resource group,
+// covering all session host VMs in that resource group for a given host pool.
+//
+// Alert rules:
+//   - Percentage CPU > 85%            (Sev 2)
+//   - Percentage CPU > 95%            (Sev 1)
+//   - Available Memory Bytes <= 2 GB  (Sev 2)
+//   - Available Memory Bytes <= 1 GB  (Sev 1)
+//   - OS Disk Bandwidth >= 85%        (Sev 2)
+//   - OS Disk Bandwidth >= 95%        (Sev 1)
+
+// ========== //
+// Parameters //
+// ========== //
+
+@description('Required. Name of the host pool (used in alert names and descriptions).')
+param hostPoolName string
+
+@description('Required. Resource ID of the resource group containing the session host VMs.')
+param vmResourceGroupId string
+
+@description('Required. Resource ID of the Action Group for notifications.')
+param actionGroupResourceId string
+
+@description('Optional. Prefix prepended to all alert names.')
+param alertNamePrefix string = 'AVD'
+
+@description('Optional. Whether alert rules auto-resolve when the condition clears.')
+param autoResolveAlert bool = true
+
+@description('Required. Azure region of the session host VMs (required for multi-resource metric alerts).')
+param location string
+
+@description('Optional. When false, CPU alert rules are not deployed.')
+param enableCpuAlerts bool = true
+
+@description('Optional. When false, available memory alert rules are not deployed.')
+param enableMemoryAlerts bool = true
+
+@description('Optional. When false, OS disk bandwidth alert rules are not deployed.')
+param enableOsDiskAlerts bool = true
+
+// ========== //
+// Variables  //
+// ========== //
+
+var descriptionHeader = 'FederalAVD - Automated Alert\n'
+
+var metricActions = [
+  {
+    actionGroupId: actionGroupResourceId
+  }
+]
+
+// ========== //
+// Resources  //
+// ========== //
+
+// CPU > 85% (Sev 2)
+resource alertCPU85 'Microsoft.Insights/metricAlerts@2018-03-01' = if (enableCpuAlerts) {
+  name: '${alertNamePrefix}-HP-VM-HighCPU85Prcnt-${hostPoolName}'
+  location: 'global'
+  properties: {
+    description: '${descriptionHeader}Session host CPU usage exceeded 85% average over 15 minutes in ${hostPoolName}. Review high-CPU processes and consider adding more session hosts or adjusting the scaling plan.'
+    severity: 2
+    enabled: true
+    scopes: [vmResourceGroupId]
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT15M'
+    targetResourceType: 'microsoft.compute/virtualmachines'
+    targetResourceRegion: location
+    criteria: {
+      'odata.type': 'Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria'
+      allOf: [
+        {
+          name: 'Metric1'
+          metricNamespace: 'microsoft.compute/virtualmachines'
+          metricName: 'Percentage CPU'
+          operator: 'GreaterThan'
+          threshold: 85
+          timeAggregation: 'Average'
+          criterionType: 'StaticThresholdCriterion'
+        }
+      ]
+    }
+    autoMitigate: autoResolveAlert
+    actions: metricActions
+  }
+}
+
+// CPU > 95% (Sev 1)
+resource alertCPU95 'Microsoft.Insights/metricAlerts@2018-03-01' = if (enableCpuAlerts) {
+  name: '${alertNamePrefix}-HP-VM-HighCPU95Prcnt-${hostPoolName}'
+  location: 'global'
+  properties: {
+    description: '${descriptionHeader}CRITICAL: Session host CPU usage exceeded 95% average over 15 minutes in ${hostPoolName}. Users on this host are likely experiencing severe performance degradation.'
+    severity: 1
+    enabled: true
+    scopes: [vmResourceGroupId]
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT15M'
+    targetResourceType: 'microsoft.compute/virtualmachines'
+    targetResourceRegion: location
+    criteria: {
+      'odata.type': 'Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria'
+      allOf: [
+        {
+          name: 'Metric1'
+          metricNamespace: 'microsoft.compute/virtualmachines'
+          metricName: 'Percentage CPU'
+          operator: 'GreaterThan'
+          threshold: 95
+          timeAggregation: 'Average'
+          criterionType: 'StaticThresholdCriterion'
+        }
+      ]
+    }
+    autoMitigate: autoResolveAlert
+    actions: metricActions
+  }
+}
+
+// Available Memory <= 2 GB (Sev 2)  - 2 GB = 2147483648 bytes
+resource alertMemory2GB 'Microsoft.Insights/metricAlerts@2018-03-01' = if (enableMemoryAlerts) {
+  name: '${alertNamePrefix}-HP-VM-AvailMemLess2GB-${hostPoolName}'
+  location: 'global'
+  properties: {
+    description: '${descriptionHeader}Available memory on a session host in ${hostPoolName} dropped below 2 GB. Users on this host may experience application slowdowns. Review memory usage and consider adding more session hosts.'
+    severity: 2
+    enabled: true
+    scopes: [vmResourceGroupId]
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT15M'
+    targetResourceType: 'microsoft.compute/virtualmachines'
+    targetResourceRegion: location
+    criteria: {
+      'odata.type': 'Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria'
+      allOf: [
+        {
+          name: 'Metric1'
+          metricNamespace: 'microsoft.compute/virtualmachines'
+          metricName: 'Available Memory Bytes'
+          operator: 'LessThanOrEqual'
+          threshold: 2147483648
+          timeAggregation: 'Average'
+          criterionType: 'StaticThresholdCriterion'
+        }
+      ]
+    }
+    autoMitigate: autoResolveAlert
+    actions: metricActions
+  }
+}
+
+// Available Memory <= 1 GB (Sev 1)  - 1 GB = 1073741824 bytes
+resource alertMemory1GB 'Microsoft.Insights/metricAlerts@2018-03-01' = if (enableMemoryAlerts) {
+  name: '${alertNamePrefix}-HP-VM-AvailMemLess1GB-${hostPoolName}'
+  location: 'global'
+  properties: {
+    description: '${descriptionHeader}CRITICAL: Available memory on a session host in ${hostPoolName} dropped below 1 GB. Users will likely experience application crashes and severe performance issues.'
+    severity: 1
+    enabled: true
+    scopes: [vmResourceGroupId]
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT15M'
+    targetResourceType: 'microsoft.compute/virtualmachines'
+    targetResourceRegion: location
+    criteria: {
+      'odata.type': 'Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria'
+      allOf: [
+        {
+          name: 'Metric1'
+          metricNamespace: 'microsoft.compute/virtualmachines'
+          metricName: 'Available Memory Bytes'
+          operator: 'LessThanOrEqual'
+          threshold: 1073741824
+          timeAggregation: 'Average'
+          criterionType: 'StaticThresholdCriterion'
+        }
+      ]
+    }
+    autoMitigate: autoResolveAlert
+    actions: metricActions
+  }
+}
+
+// OS Disk Bandwidth >= 85% (Sev 2)
+resource alertOSDiskBandwidth85 'Microsoft.Insights/metricAlerts@2018-03-01' = if (enableOsDiskAlerts) {
+  name: '${alertNamePrefix}-HP-VM-OSDiskBW85Prcnt-${hostPoolName}'
+  location: 'global'
+  properties: {
+    description: '${descriptionHeader}OS Disk bandwidth consumption on a session host in ${hostPoolName} is at or above 85%. The VM is nearing its disk IOPS limit. Consider moving to a larger or premium disk SKU.'
+    severity: 2
+    enabled: true
+    scopes: [vmResourceGroupId]
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT15M'
+    targetResourceType: 'microsoft.compute/virtualmachines'
+    targetResourceRegion: location
+    criteria: {
+      'odata.type': 'Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria'
+      allOf: [
+        {
+          name: 'Metric1'
+          metricNamespace: 'microsoft.compute/virtualmachines'
+          metricName: 'OS Disk Bandwidth Consumed Percentage'
+          operator: 'GreaterThanOrEqual'
+          threshold: 85
+          timeAggregation: 'Average'
+          criterionType: 'StaticThresholdCriterion'
+          dimensions: [
+            {
+              name: 'LUN'
+              operator: 'Include'
+              values: ['*']
+            }
+          ]
+        }
+      ]
+    }
+    autoMitigate: autoResolveAlert
+    actions: metricActions
+  }
+}
+
+// OS Disk Bandwidth >= 95% (Sev 1)
+resource alertOSDiskBandwidth95 'Microsoft.Insights/metricAlerts@2018-03-01' = if (enableOsDiskAlerts) {
+  name: '${alertNamePrefix}-HP-VM-OSDiskBW95Prcnt-${hostPoolName}'
+  location: 'global'
+  properties: {
+    description: '${descriptionHeader}CRITICAL: OS Disk bandwidth on a session host in ${hostPoolName} is at or above 95%. Users will experience severe I/O latency. Upgrade disk SKU immediately.'
+    severity: 1
+    enabled: true
+    scopes: [vmResourceGroupId]
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT15M'
+    targetResourceType: 'microsoft.compute/virtualmachines'
+    targetResourceRegion: location
+    criteria: {
+      'odata.type': 'Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria'
+      allOf: [
+        {
+          name: 'Metric1'
+          metricNamespace: 'microsoft.compute/virtualmachines'
+          metricName: 'OS Disk Bandwidth Consumed Percentage'
+          operator: 'GreaterThanOrEqual'
+          threshold: 95
+          timeAggregation: 'Average'
+          criterionType: 'StaticThresholdCriterion'
+          dimensions: [
+            {
+              name: 'LUN'
+              operator: 'Include'
+              values: ['*']
+            }
+          ]
+        }
+      ]
+    }
+    autoMitigate: autoResolveAlert
+    actions: metricActions
+  }
+}

--- a/deployments/add-ons/avdAlerts/scripts/Get-StorAcctInfo.ps1
+++ b/deployments/add-ons/avdAlerts/scripts/Get-StorAcctInfo.ps1
@@ -1,0 +1,120 @@
+# AVD Alert Solution - Storage Account Information Collector
+# Runbook for Azure Automation Account.
+# Queries FSLogix Azure Files shares and writes comma-delimited usage data to the
+# Automation Account job stream (which flows to Log Analytics via diagnostic settings).
+#
+# Output format per file share (comma-separated, 9 fields, indices 0-8):
+#   [0] StorageType       (AzFiles)
+#   [1] StorageAccount
+#   [2] ResourceGroup
+#   [3] ShareName
+#   [4] QuotaGiB
+#   [5] UsedGiB
+#   [6] PercentAvailable
+#   [7] ResourceId        (share resource ID)
+#
+# This output format is consumed by Log Analytics Kusto queries in the AVD alert rules.
+#
+# Configuration is read from Automation Account variables:
+#   StorageAccountResourceIDs - JSON array of storage account resource IDs
+#   ResourceManagerUri        - ARM endpoint URI for this cloud
+
+$ErrorActionPreference = 'Stop'
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 -bor [Net.SecurityProtocolType]::Tls13
+
+#region Configuration
+
+$ResourceManagerUri       = Get-AutomationVariable -Name 'ResourceManagerUri'
+$StorageAccountResourceIDsJson = Get-AutomationVariable -Name 'StorageAccountResourceIDs'
+
+if ([string]::IsNullOrEmpty($ResourceManagerUri)) { throw 'ResourceManagerUri automation variable is not set.' }
+if ([string]::IsNullOrEmpty($StorageAccountResourceIDsJson)) { throw 'StorageAccountResourceIDs automation variable is not set.' }
+if (-not $ResourceManagerUri.EndsWith('/')) { $ResourceManagerUri = "$ResourceManagerUri/" }
+
+$StorageAccountResourceIDs = $StorageAccountResourceIDsJson | ConvertFrom-Json
+if ($null -eq $StorageAccountResourceIDs -or @($StorageAccountResourceIDs).Count -eq 0) {
+    Write-Output 'No storage account resource IDs configured. Exiting.'
+    return
+}
+
+#endregion Configuration
+
+#region Authentication
+
+try {
+    Connect-AzAccount -Identity | Out-Null
+    $tokenObj = Get-AzAccessToken -ResourceUrl ($ResourceManagerUri.TrimEnd('/'))
+    $ArmToken = if ($tokenObj.Token -is [System.Security.SecureString]) {
+        [System.Net.NetworkCredential]::new('', $tokenObj.Token).Password
+    } else {
+        $tokenObj.Token
+    }
+    if ([string]::IsNullOrEmpty($ArmToken)) { throw 'Token was null or empty.' }
+}
+catch {
+    throw "Failed to acquire ARM access token via managed identity: $_"
+}
+
+$Header = @{
+    Authorization  = "Bearer $ArmToken"
+    'Content-Type' = 'application/json'
+}
+
+#endregion Authentication
+
+#region Collect Storage Data
+
+$StorageApiVersion = '2023-05-01'
+
+foreach ($StorageAccountResourceId in @($StorageAccountResourceIDs)) {
+    $StorageAccountResourceId = $StorageAccountResourceId.Trim()
+    if ([string]::IsNullOrEmpty($StorageAccountResourceId)) { continue }
+
+    $IdParts        = $StorageAccountResourceId -split '/'
+    $SubId          = $IdParts[2]
+    $ResourceGroup  = $IdParts[4]
+    $StorageAccount = $IdParts[8]
+
+    if ([string]::IsNullOrEmpty($StorageAccount)) {
+        Write-Warning "Could not parse storage account name from resource ID: $StorageAccountResourceId"
+        continue
+    }
+
+    # List all file shares with usage statistics
+    $SharesUri = "${ResourceManagerUri}subscriptions/${SubId}/resourceGroups/${ResourceGroup}/providers/Microsoft.Storage/storageAccounts/${StorageAccount}/fileServices/default/shares?api-version=${StorageApiVersion}&`$expand=stats"
+
+    try {
+        $Shares = (Invoke-RestMethod -Headers $Header -Method 'GET' -Uri $SharesUri).value
+    }
+    catch {
+        Write-Warning "Failed to list shares for ${StorageAccount}: $_"
+        continue
+    }
+
+    if ($null -eq $Shares -or @($Shares).Count -eq 0) {
+        Write-Warning "No file shares found in storage account: $StorageAccount"
+        continue
+    }
+
+    foreach ($Share in @($Shares)) {
+        $ShareName    = $Share.name
+        $ShareProps   = $Share.properties
+        $QuotaGiB     = $ShareProps.shareQuota
+        $UsedBytes    = $ShareProps.shareUsageBytes
+        $UsedGiB      = if ($null -ne $UsedBytes) { [math]::Round($UsedBytes / 1GB, 2) } else { 0 }
+        $PercentAvail = if ($QuotaGiB -gt 0 -and $null -ne $UsedBytes) {
+            [math]::Round(100 - ($UsedGiB / $QuotaGiB * 100), 1)
+        } else {
+            100
+        }
+
+        # Build share resource ID from storage account resource ID and share name
+        $ShareResourceId = "${StorageAccountResourceId}/fileServices/default/shares/${ShareName}"
+
+        # Write output in comma-delimited format matching the Log Analytics KQL queries
+        Write-Output ('AzFiles,' + $StorageAccount + ',' + $ResourceGroup + ',' + $ShareName + ',' +
+            $QuotaGiB + ',' + $UsedGiB + ',' + $PercentAvail + ',' + $ShareResourceId)
+    }
+}
+
+#endregion Collect Storage Data

--- a/deployments/add-ons/avdAlerts/uiFormDefinition.json
+++ b/deployments/add-ons/avdAlerts/uiFormDefinition.json
@@ -1,0 +1,663 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2021-09-09/uiFormDefinition.schema.json",
+    "view": {
+        "kind": "Form",
+        "properties": {
+            "title": "AVD Alerts Add-On",
+            "steps": [
+                {
+                    "name": "basics",
+                    "label": "Deployment Basics",
+                    "elements": [
+                        {
+                            "name": "infoBox",
+                            "type": "Microsoft.Common.TextBlock",
+                            "options": {
+                                "text": "Deploys Azure Monitor alert rules for one or more AVD host pools. Covers host pool capacity, session host health, FSLogix profile issues, VM performance, service health, and (optionally) Azure Files / ANF storage capacity. Alert rules are created as Log Analytics scheduled query rules and native metric alerts. No virtual machines are deployed."
+                            }
+                        },
+                        {
+                            "name": "resourceScope",
+                            "type": "Microsoft.Common.ResourceScope",
+                            "subscription": {
+                                "resourceProviders": [
+                                    "Microsoft.Automation/automationAccounts",
+                                    "Microsoft.Insights/scheduledQueryRules",
+                                    "Microsoft.Insights/metricAlerts",
+                                    "Microsoft.Insights/activityLogAlerts"
+                                ]
+                            },
+                            "location": {
+                                "label": "Region",
+                                "toolTip": "Azure region where the Automation Account and alert rules will be deployed. Should match the region of your host pool and Log Analytics workspace.",
+                                "resourceTypes": [
+                                    "Microsoft.Automation/automationAccounts"
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "alertsRg",
+                    "label": "Alerts Resource Group",
+                    "elements": [
+                        {
+                            "name": "infoBox",
+                            "type": "Microsoft.Common.TextBlock",
+                            "options": {
+                                "text": "Select or create the resource group where the Automation Account and alert rule resources will be deployed. This is typically a dedicated monitoring or operations resource group, separate from the resource groups containing the session host VMs."
+                            }
+                        },
+                        {
+                            "name": "createOrUse",
+                            "type": "Microsoft.Common.OptionsGroup",
+                            "label": "Resource Group",
+                            "defaultValue": "Use existing",
+                            "toolTip": "Choose whether to create a new resource group or deploy into an existing one.",
+                            "constraints": {
+                                "required": true,
+                                "allowedValues": [
+                                    {
+                                        "label": "Use existing",
+                                        "value": false
+                                    },
+                                    {
+                                        "label": "Create new",
+                                        "value": true
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "resourceGroupsApi",
+                            "type": "Microsoft.Solutions.ArmApiControl",
+                            "condition": "[equals(steps('alertsRg').createOrUse, false)]",
+                            "request": {
+                                "method": "GET",
+                                "path": "[concat(steps('basics').resourceScope.subscription.id, '/resourcegroups?api-version=2021-04-01')]"
+                            }
+                        },
+                        {
+                            "name": "existingResourceGroupName",
+                            "type": "Microsoft.Common.DropDown",
+                            "label": "Existing Resource Group",
+                            "toolTip": "Select the existing resource group to deploy into.",
+                            "visible": "[equals(steps('alertsRg').createOrUse, false)]",
+                            "constraints": {
+                                "required": "[equals(steps('alertsRg').createOrUse, false)]",
+                                "allowedValues": "[map(steps('alertsRg').resourceGroupsApi.value, (rg) => parse(concat('{\"label\":\"', rg.name, '\",\"description\":\"', rg.location, '\",\"value\":\"', rg.name, '\"}')))]"
+                            }
+                        },
+                        {
+                            "name": "newResourceGroupName",
+                            "type": "Microsoft.Common.TextBox",
+                            "label": "New Resource Group Name",
+                            "toolTip": "Name for the new resource group to create in the selected subscription and region.",
+                            "visible": "[equals(steps('alertsRg').createOrUse, true)]",
+                            "placeholder": "rg-avd-alerts-p-eus2",
+                            "constraints": {
+                                "required": "[equals(steps('alertsRg').createOrUse, true)]",
+                                "regex": "^[a-zA-Z0-9()_.\\-]{1,90}$",
+                                "validationMessage": "Resource group names can be 1-90 characters and contain letters, digits, underscores, hyphens, parentheses, and periods."
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "monitoring",
+                    "label": "Monitoring",
+                    "elements": [
+                        {
+                            "name": "infoBox",
+                            "type": "Microsoft.Common.TextBlock",
+                            "options": {
+                                "text": "Select the Log Analytics Workspace where AVD diagnostic data is collected (configured during the host pool deployment) and the Action Group that will receive alert notifications."
+                            }
+                        },
+                        {
+                            "name": "logAnalyticsWorkspace",
+                            "type": "Microsoft.Solutions.ResourceSelector",
+                            "label": "Log Analytics Workspace",
+                            "toolTip": "The workspace where AVD diagnostic data flows (WVDConnections, WVDAgentHealthStatus, WVDErrors, Perf, Event). This workspace was configured when the host pool was deployed.",
+                            "resourceType": "Microsoft.OperationalInsights/workspaces",
+                            "options": {
+                                "filter": {
+                                    "subscription": "onBasics"
+                                }
+                            },
+                            "constraints": {
+                                "required": true
+                            }
+                        },
+                        {
+                            "name": "actionGroup",
+                            "type": "Microsoft.Solutions.ResourceSelector",
+                            "label": "Action Group",
+                            "toolTip": "The action group to notify when an alert fires (email, SMS, webhook, ITSM, etc.). Create this in Azure Monitor before deploying.",
+                            "resourceType": "Microsoft.Insights/actionGroups",
+                            "options": {
+                                "filter": {
+                                    "subscription": "onBasics"
+                                }
+                            },
+                            "constraints": {
+                                "required": true
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "hostPools",
+                    "label": "Host Pools",
+                    "elements": [
+                        {
+                            "name": "infoBox",
+                            "type": "Microsoft.Common.TextBlock",
+                            "options": {
+                                "text": "Add each AVD host pool to monitor. For each host pool you must also identify the resource group that contains its session host VMs — this is a separate resource group from the host pool itself in a FederalAVD deployment. The VM Resource Group column is auto-populated from the hostsResourceGroupId tag that FederalAVD sets on every host pool at deployment time. You can override it if your VMs are in a different resource group."
+                            }
+                        },
+                        {
+                            "name": "hostPoolsApi",
+                            "type": "Microsoft.Solutions.ArmApiControl",
+                            "request": {
+                                "method": "GET",
+                                "path": "[concat(steps('basics').resourceScope.subscription.id, '/providers/Microsoft.DesktopVirtualization/hostPools?api-version=2024-04-03')]"
+                            }
+                        },
+                        {
+                            "name": "rgApi",
+                            "type": "Microsoft.Solutions.ArmApiControl",
+                            "request": {
+                                "method": "GET",
+                                "path": "[concat(steps('basics').resourceScope.subscription.id, '/resourcegroups?api-version=2021-04-01')]"
+                            }
+                        },
+                        {
+                            "name": "noTagWarning",
+                            "type": "Microsoft.Common.InfoBox",
+                            "visible": "[not(empty(filter(coalesce(steps('hostPools').hostPoolsApi.value, parse('[]')), (hp) => empty(coalesce(hp.tags.hostsResourceGroupId, '')))))]",
+                            "options": {
+                                "style": "Warning",
+                                "text": "One or more host pools in this subscription do not have the hostsResourceGroupId tag. For those pools no '(from tag)' entry will appear in the VM Resource Group dropdown — select the correct resource group from the full list."
+                            }
+                        },
+                        {
+                            "name": "hostPoolGrid",
+                            "type": "Microsoft.Common.EditableGrid",
+                            "ariaLabel": "Host pools to monitor",
+                            "label": "Host Pools",
+                            "constraints": {
+                                "width": "Full",
+                                "rows": {
+                                    "count": {
+                                        "min": 1,
+                                        "max": 20
+                                    }
+                                },
+                                "columns": [
+                                    {
+                                        "id": "hostPool",
+                                        "header": "Host Pool",
+                                        "width": "2fr",
+                                        "element": {
+                                            "type": "Microsoft.Common.DropDown",
+                                            "placeholder": "Select a host pool",
+                                            "toolTip": "Select the AVD host pool to monitor. The VM Resource Group is read from the hostsResourceGroupId tag and embedded in the selection — leave the override blank to use it.",
+                                            "multiLine": true,
+                                            "constraints": {
+                                                "required": true,
+                                                "allowedValues": "[map(steps('hostPools').hostPoolsApi.value, (hp) => parse(concat('{\"label\":\"', hp.name, '\",\"description\":\"Host Pool RG: ', first(skip(split(hp.id, '/'), 4)), if(empty(coalesce(hp.tags.hostsResourceGroupId, '')), ' | VM RG: NOT SET - enter override', concat(' | VM RG: ', last(split(hp.tags.hostsResourceGroupId, '/')))), '\",\"value\":\"', hp.id, '|', coalesce(hp.tags.hostsResourceGroupId, ''), '\"}')))]"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "id": "vmRg",
+                                        "header": "VM Resource Group",
+                                        "width": "2fr",
+                                        "element": {
+                                            "type": "Microsoft.Common.DropDown",
+                                            "placeholder": "Leave blank to use hostsResourceGroupId tag",
+                                            "toolTip": "Leave blank to use the resource group from the hostsResourceGroupId tag (shown in the Host Pool description). Required only when the tag is not set.",
+                                            "multiLine": true,
+                                            "constraints": {
+                                                "required": "[empty(last(split(last(take(steps('hostPools').hostPoolGrid, $rowIndex)).hostPool, '|')))]",
+                                                "allowedValues": "[map(steps('hostPools').rgApi.value, (rg) => parse(concat('{\"label\":\"', rg.name, '\",\"description\":\"', rg.location, '\",\"value\":\"', rg.id, '\"}')))]"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "vmRgInfo",
+                            "type": "Microsoft.Common.InfoBox",
+                            "options": {
+                                "style": "Info",
+                                "text": "VM metric alerts (CPU, memory, disk bandwidth) are scoped to the VM Resource Group. Log-based alerts query the Log Analytics workspace you selected on the Monitoring tab and are automatically filtered to each host pool by name."
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "storage",
+                    "label": "Storage (Optional)",
+                    "elements": [
+                        {
+                            "name": "storageSection",
+                            "type": "Microsoft.Common.Section",
+                            "label": "Azure Files Storage Accounts",
+                            "elements": [
+                                {
+                                    "name": "enableStorageAlerts",
+                                    "type": "Microsoft.Common.CheckBox",
+                                    "label": "Enable Azure Files storage alerts",
+                                    "defaultValue": false,
+                                    "toolTip": "Deploy metric and log-based alerts for Azure Files Premium storage accounts used for FSLogix profile containers. Requires an Automation Account runbook to collect share usage data."
+                                },
+                                {
+                                    "name": "storageAccountsApi",
+                                    "type": "Microsoft.Solutions.ArmApiControl",
+                                    "condition": "[steps('storage').storageSection.enableStorageAlerts]",
+                                    "request": {
+                                        "method": "GET",
+                                        "path": "[concat(steps('basics').resourceScope.subscription.id, '/providers/Microsoft.Storage/storageAccounts?api-version=2023-05-01')]"
+                                    }
+                                },
+                                {
+                                    "name": "noStorageWarning",
+                                    "type": "Microsoft.Common.InfoBox",
+                                    "visible": "[and(steps('storage').storageSection.enableStorageAlerts, empty(filter(coalesce(steps('storage').storageSection.storageAccountsApi.value, parse('[]')), (sa) => equals(sa.kind, 'FileStorage'))))]",
+                                    "options": {
+                                        "style": "Warning",
+                                        "text": "No Azure Files Premium (FileStorage kind) storage accounts found in this subscription. Verify the correct subscription is selected."
+                                    }
+                                },
+                                {
+                                    "name": "storageAccountGrid",
+                                    "type": "Microsoft.Common.EditableGrid",
+                                    "ariaLabel": "Azure Files Premium storage accounts for FSLogix",
+                                    "label": "Storage Accounts",
+                                    "visible": "[steps('storage').storageSection.enableStorageAlerts]",
+                                    "constraints": {
+                                        "width": "Full",
+                                        "rows": {
+                                            "count": {
+                                                "min": 0,
+                                                "max": 50
+                                            }
+                                        },
+                                        "columns": [
+                                            {
+                                                "id": "storageAccountId",
+                                                "header": "Storage Account",
+                                                "width": "Full",
+                                                "element": {
+                                                    "type": "Microsoft.Common.DropDown",
+                                                    "placeholder": "Select an Azure Files Premium storage account",
+                                                    "toolTip": "Select the Azure Files Premium (kind: FileStorage) storage account used for FSLogix profile containers.",
+                                                    "multiLine": true,
+                                                    "constraints": {
+                                                        "required": true,
+                                                        "allowedValues": "[map(filter(coalesce(steps('storage').storageSection.storageAccountsApi.value, parse('[]')), (sa) => equals(sa.kind, 'FileStorage')), (sa) => parse(concat('{\"label\":\"', sa.name, '\",\"description\":\"Resource Group: ', first(skip(split(sa.id, '/'), 4)), '\",\"value\":\"', sa.id, '\"}')))]"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "anfSection",
+                            "type": "Microsoft.Common.Section",
+                            "label": "Azure NetApp Files Volumes",
+                            "elements": [
+                                {
+                                    "name": "enableAnfAlerts",
+                                    "type": "Microsoft.Common.CheckBox",
+                                    "label": "Enable Azure NetApp Files volume alerts",
+                                    "defaultValue": false,
+                                    "toolTip": "Deploy metric-based capacity alerts for Azure NetApp Files volumes used for FSLogix profile containers."
+                                },
+                                {
+                                    "name": "anfVolumeInfo",
+                                    "type": "Microsoft.Common.InfoBox",
+                                    "visible": "[steps('storage').anfSection.enableAnfAlerts]",
+                                    "options": {
+                                        "style": "Info",
+                                        "text": "Enter the full resource ID of each ANF volume. Format: /subscriptions/{id}/resourceGroups/{rg}/providers/Microsoft.NetApp/netAppAccounts/{account}/capacityPools/{pool}/volumes/{volume}"
+                                    }
+                                },
+                                {
+                                    "name": "anfVolumeGrid",
+                                    "type": "Microsoft.Common.EditableGrid",
+                                    "ariaLabel": "ANF volumes for FSLogix",
+                                    "label": "ANF Volumes",
+                                    "visible": "[steps('storage').anfSection.enableAnfAlerts]",
+                                    "constraints": {
+                                        "width": "Full",
+                                        "rows": {
+                                            "count": {
+                                                "min": 0,
+                                                "max": 10
+                                            }
+                                        },
+                                        "columns": [
+                                            {
+                                                "id": "volumeId",
+                                                "header": "ANF Volume Resource ID",
+                                                "width": "Full",
+                                                "element": {
+                                                    "type": "Microsoft.Common.TextBox",
+                                                    "placeholder": "/subscriptions/.../resourceGroups/.../providers/Microsoft.NetApp/netAppAccounts/.../capacityPools/.../volumes/...",
+                                                    "toolTip": "Full ARM resource ID of the ANF volume.",
+                                                    "constraints": {
+                                                        "required": true,
+                                                        "regex": "^/subscriptions/[^/]+/resourceGroups/[^/]+/providers/Microsoft\\.NetApp/netAppAccounts/[^/]+/capacityPools/[^/]+/volumes/[^/]+$",
+                                                        "validationMessage": "Must be a valid ANF volume resource ID."
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "advanced",
+                    "label": "Advanced",
+                    "elements": [
+                        {
+                            "name": "infoBox",
+                            "type": "Microsoft.Common.InfoBox",
+                            "options": {
+                                "style": "Info",
+                                "text": "Use this page to override alert naming, the Automation Account name, and deployment behavior. Leave all fields at their defaults for a standard first deployment."
+                            }
+                        },
+                        {
+                            "name": "alertSettings",
+                            "type": "Microsoft.Common.Section",
+                            "label": "Alert Settings",
+                            "elements": [
+                                {
+                                    "name": "alertNamePrefix",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Alert Name Prefix",
+                                    "defaultValue": "AVD",
+                                    "toolTip": "Short prefix prepended to every alert rule name. Change this if deploying alerts for multiple environments in the same subscription to avoid name collisions.",
+                                    "constraints": {
+                                        "required": true,
+                                        "regex": "^[a-zA-Z0-9-]{1,10}$",
+                                        "validationMessage": "Must be 1-10 alphanumeric characters or hyphens."
+                                    }
+                                },
+                                {
+                                    "name": "autoResolveAlert",
+                                    "type": "Microsoft.Common.CheckBox",
+                                    "label": "Auto-resolve alerts when condition clears",
+                                    "defaultValue": true,
+                                    "toolTip": "When checked, alert rules automatically close when the underlying condition is no longer detected during the next evaluation."
+                                }
+                            ]
+                        },
+                        {
+                            "name": "alertCategories",
+                            "type": "Microsoft.Common.Section",
+                            "label": "Alert Categories",
+                            "elements": [
+                                {
+                                    "name": "categoriesInfo",
+                                    "type": "Microsoft.Common.InfoBox",
+                                    "options": {
+                                        "style": "Info",
+                                        "text": "Uncheck any category you do not need. Unchecked categories are not deployed and will be removed on the next redeployment."
+                                    }
+                                },
+                                {
+                                    "name": "enableCapacityAlerts",
+                                    "type": "Microsoft.Common.CheckBox",
+                                    "label": "Host Pool Capacity Alerts (50% / 85% / 95%)",
+                                    "defaultValue": true,
+                                    "toolTip": "Alert when host pool load reaches 50%, 85%, or 95% capacity."
+                                },
+                                {
+                                    "name": "enableAvailabilityAlerts",
+                                    "type": "Microsoft.Common.CheckBox",
+                                    "label": "Host Availability & VM Health Alerts",
+                                    "defaultValue": true,
+                                    "toolTip": "Alert when session hosts are unhealthy, no resources are available, or VM health checks fail."
+                                },
+                                {
+                                    "name": "enableConnectionAlerts",
+                                    "type": "Microsoft.Common.CheckBox",
+                                    "label": "Connection & Disconnected Session Alerts",
+                                    "defaultValue": true,
+                                    "toolTip": "Alert on user connection failures, sessions disconnected > 24h / 72h, and slow logons (> 2 minutes)."
+                                },
+                                {
+                                    "name": "enableLocalDiskAlerts",
+                                    "type": "Microsoft.Common.CheckBox",
+                                    "label": "Session Host Local Disk Space Alerts",
+                                    "defaultValue": true,
+                                    "toolTip": "Alert when C: drive free space drops to 10% or 5%. Disable if using ephemeral OS disks."
+                                },
+                                {
+                                    "name": "enableFslogixAlerts",
+                                    "type": "Microsoft.Common.CheckBox",
+                                    "label": "FSLogix Profile Alerts",
+                                    "defaultValue": true,
+                                    "toolTip": "Alert on FSLogix profile errors: VHD full, network issues, attach failures, service disabled, compaction failures. Disable if not using FSLogix."
+                                },
+                                {
+                                    "name": "enableCpuAlerts",
+                                    "type": "Microsoft.Common.CheckBox",
+                                    "label": "VM CPU Alerts (85% / 95%)",
+                                    "defaultValue": true,
+                                    "toolTip": "Alert when average session host CPU exceeds 85% or 95% over 15 minutes."
+                                },
+                                {
+                                    "name": "enableMemoryAlerts",
+                                    "type": "Microsoft.Common.CheckBox",
+                                    "label": "VM Available Memory Alerts (< 2 GB / < 1 GB)",
+                                    "defaultValue": true,
+                                    "toolTip": "Alert when available memory on a session host drops below 2 GB or 1 GB."
+                                },
+                                {
+                                    "name": "enableOsDiskAlerts",
+                                    "type": "Microsoft.Common.CheckBox",
+                                    "label": "VM OS Disk Bandwidth Alerts (85% / 95%)",
+                                    "defaultValue": true,
+                                    "toolTip": "Alert when OS disk bandwidth consumption exceeds 85% or 95%. Disable if using ephemeral or high-IOPS disks where this is expected."
+                                },
+                                {
+                                    "name": "enableStorageLatencyAlerts",
+                                    "type": "Microsoft.Common.CheckBox",
+                                    "label": "Storage Latency Alerts (> 50ms / > 100ms)",
+                                    "defaultValue": true,
+                                    "visible": "[steps('storage').storageSection.enableStorageAlerts]",
+                                    "toolTip": "Alert when server or end-to-end latency on Azure Files storage accounts exceeds 50ms or 100ms."
+                                },
+                                {
+                                    "name": "enableStorageAvailabilityAlerts",
+                                    "type": "Microsoft.Common.CheckBox",
+                                    "label": "Storage Availability Alerts (< 99%)",
+                                    "defaultValue": true,
+                                    "visible": "[steps('storage').storageSection.enableStorageAlerts]",
+                                    "toolTip": "Alert when storage account availability drops below 99%."
+                                },
+                                {
+                                    "name": "enableStorageThrottlingAlerts",
+                                    "type": "Microsoft.Common.CheckBox",
+                                    "label": "Storage Throttling Alerts",
+                                    "defaultValue": true,
+                                    "visible": "[steps('storage').storageSection.enableStorageAlerts]",
+                                    "toolTip": "Alert when Azure Files share IOPS are being throttled."
+                                },
+                                {
+                                    "name": "enableAnfCapacityAlerts",
+                                    "type": "Microsoft.Common.CheckBox",
+                                    "label": "ANF Volume Capacity Alerts (>= 85% / >= 95%)",
+                                    "defaultValue": true,
+                                    "visible": "[steps('storage').anfSection.enableAnfAlerts]",
+                                    "toolTip": "Alert when ANF volume consumed capacity reaches 85% or 95%."
+                                },
+                                {
+                                    "name": "enableServiceHealthAlerts",
+                                    "type": "Microsoft.Common.CheckBox",
+                                    "label": "Azure Service Health Alerts",
+                                    "defaultValue": true,
+                                    "toolTip": "Alert on Azure service incidents, planned maintenance, health advisories, and security advisories affecting this subscription."
+                                }
+                            ]
+                        },
+                        {
+                            "name": "resourceNames",
+                            "type": "Microsoft.Common.Section",
+                            "label": "Resource Name Override",
+                            "visible": "[steps('storage').storageSection.enableStorageAlerts]",
+                            "elements": [
+                                {
+                                    "name": "defaultNamePreview",
+                                    "type": "Microsoft.Common.TextBlock",
+                                    "options": {
+                                        "text": "Default Automation Account name: aa-avd-alerts-{locAbbrev}  (e.g. aa-avd-alerts-eus2)"
+                                    }
+                                },
+                                {
+                                    "name": "enableNameOverride",
+                                    "type": "Microsoft.Common.CheckBox",
+                                    "label": "Override Automation Account Name",
+                                    "defaultValue": false,
+                                    "toolTip": "Check to specify an explicit Automation Account name instead of the auto-generated name."
+                                },
+                                {
+                                    "name": "automationAccountNameOverride",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "visible": "[steps('advanced').resourceNames.enableNameOverride]",
+                                    "label": "Automation Account Name",
+                                    "placeholder": "aa-avd-alerts-{locAbbrev}",
+                                    "toolTip": "Explicit name for the Automation Account. Must be 6-50 characters, start with a letter, end with a letter or digit, and contain only letters, digits, and hyphens.",
+                                    "constraints": {
+                                        "required": false,
+                                        "validations": [
+                                            {
+                                                "regex": "^$|^[a-zA-Z][a-zA-Z0-9-]{4,48}[a-zA-Z0-9]$",
+                                                "message": "Must be 6-50 characters, start with a letter, end with a letter or digit, and contain only letters, digits, and hyphens."
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "runbookSection",
+                            "type": "Microsoft.Common.Section",
+                            "label": "Runbook Configuration",
+                            "visible": "[steps('storage').storageSection.enableStorageAlerts]",
+                            "elements": [
+                                {
+                                    "name": "runbookInfo",
+                                    "type": "Microsoft.Common.InfoBox",
+                                    "options": {
+                                        "style": "Info",
+                                        "text": "Azure Automation downloads the runbook from the URI below during deployment. The default URI points to the FederalAVD GitHub repository and works for Azure Commercial and Azure Government.\n\nAIR-GAPPED ENVIRONMENTS (Azure Government Secret / Top Secret): Clear this field entirely. The runbook will be created in an unpublished state. After deployment, publish it manually from a machine with portal or PowerShell access."
+                                    }
+                                },
+                                {
+                                    "name": "runbookContentUriStorage",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Storage Runbook URI",
+                                    "defaultValue": "https://raw.githubusercontent.com/Azure/FederalAVD/main/deployments/add-ons/avdAlerts/scripts/Get-StorAcctInfo.ps1",
+                                    "toolTip": "URI of the PowerShell runbook that collects Azure Files share usage data. Clear for air-gapped environments.",
+                                    "constraints": {
+                                        "required": false,
+                                        "validations": [
+                                            {
+                                                "regex": "^$|^https?://.+\\.ps1$",
+                                                "message": "Must be a valid HTTPS URI ending in .ps1, or leave blank for air-gapped deployments."
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "scheduleSection",
+                            "type": "Microsoft.Common.Section",
+                            "label": "Job Schedule",
+                            "visible": "[steps('storage').storageSection.enableStorageAlerts]",
+                            "elements": [
+                                {
+                                    "name": "scheduleWarning",
+                                    "type": "Microsoft.Common.InfoBox",
+                                    "options": {
+                                        "style": "Warning",
+                                        "text": "REDEPLOYMENT NOTICE: Azure Automation caches the runbook-to-schedule link by automation account name. On first deployment: leave 'Create job schedule links' checked. On every redeployment: uncheck it — Azure Automation raises a Conflict error if the link already exists."
+                                    }
+                                },
+                                {
+                                    "name": "createJobSchedules",
+                                    "type": "Microsoft.Common.CheckBox",
+                                    "label": "Create job schedule links",
+                                    "defaultValue": true,
+                                    "toolTip": "Check on first deployment. Uncheck on redeployments to avoid the 'jobSchedule already exists' conflict."
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "tags",
+                    "label": "Tags",
+                    "elements": [
+                        {
+                            "name": "tags",
+                            "type": "Microsoft.Common.TagsByResource",
+                            "resources": [
+                                "Microsoft.Automation/automationAccounts"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "outputs": {
+            "kind": "Subscription",
+            "location": "[steps('basics').resourceScope.location.name]",
+            "subscriptionId": "[steps('basics').resourceScope.subscription.subscriptionId]",
+            "parameters": {
+                "location": "[steps('basics').resourceScope.location.name]",
+                "resourceGroupName": "[if(steps('alertsRg').createOrUse, steps('alertsRg').newResourceGroupName, steps('alertsRg').existingResourceGroupName)]",
+                "createResourceGroup": "[steps('alertsRg').createOrUse]",
+                "logAnalyticsWorkspaceResourceId": "[steps('monitoring').logAnalyticsWorkspace.id]",
+                "actionGroupResourceId": "[steps('monitoring').actionGroup.id]",
+                "hostPoolInfo": "[map(filter(steps('hostPools').hostPoolGrid, (row) => not(empty(row.hostPool))), (row) => parse(concat('{\"hostPoolResourceId\":\"', first(split(row.hostPool, '|')), '\",\"vmResourceGroupId\":\"', if(empty(row.vmRg), last(split(row.hostPool, '|')), row.vmRg), '\"}')))]",
+                "storageAccountResourceIds": "[if(steps('storage').storageSection.enableStorageAlerts, map(filter(steps('storage').storageSection.storageAccountGrid, (row) => not(empty(row.storageAccountId))), (row) => row.storageAccountId), parse('[]'))]",
+                "anfVolumeResourceIds": "[if(steps('storage').anfSection.enableAnfAlerts, map(filter(steps('storage').anfSection.anfVolumeGrid, (row) => not(empty(row.volumeId))), (row) => row.volumeId), parse('[]'))]",
+                "alertNamePrefix": "[steps('advanced').alertSettings.alertNamePrefix]",
+                "autoResolveAlert": "[steps('advanced').alertSettings.autoResolveAlert]",
+                "automationAccountNameOverride": "[if(steps('advanced').resourceNames.enableNameOverride, coalesce(steps('advanced').resourceNames.automationAccountNameOverride, ''), '')]",
+                "runbookContentUriStorage": "[if(steps('storage').storageSection.enableStorageAlerts, coalesce(steps('advanced').runbookSection.runbookContentUriStorage, ''), '')]",
+                "createJobSchedules": "[if(steps('storage').storageSection.enableStorageAlerts, steps('advanced').scheduleSection.createJobSchedules, true)]",
+                "enableCapacityAlerts": "[steps('advanced').alertCategories.enableCapacityAlerts]",
+                "enableAvailabilityAlerts": "[steps('advanced').alertCategories.enableAvailabilityAlerts]",
+                "enableConnectionAlerts": "[steps('advanced').alertCategories.enableConnectionAlerts]",
+                "enableLocalDiskAlerts": "[steps('advanced').alertCategories.enableLocalDiskAlerts]",
+                "enableFslogixAlerts": "[steps('advanced').alertCategories.enableFslogixAlerts]",
+                "enableCpuAlerts": "[steps('advanced').alertCategories.enableCpuAlerts]",
+                "enableMemoryAlerts": "[steps('advanced').alertCategories.enableMemoryAlerts]",
+                "enableOsDiskAlerts": "[steps('advanced').alertCategories.enableOsDiskAlerts]",
+                "enableStorageLatencyAlerts": "[steps('advanced').alertCategories.enableStorageLatencyAlerts]",
+                "enableStorageAvailabilityAlerts": "[steps('advanced').alertCategories.enableStorageAvailabilityAlerts]",
+                "enableStorageThrottlingAlerts": "[steps('advanced').alertCategories.enableStorageThrottlingAlerts]",
+                "enableAnfCapacityAlerts": "[steps('advanced').alertCategories.enableAnfCapacityAlerts]",
+                "enableServiceHealthAlerts": "[steps('advanced').alertCategories.enableServiceHealthAlerts]",
+                "tags": "[steps('tags').tags]"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Wraps the ADMX template download block in a `try/catch` in both `Configure-EdgePolicy.ps1` and `Configure-Office365.ps1` so that a failed download (e.g. no internet access in an air-gapped image build) logs a warning and continues instead of terminating the script.

## Changes

### `customer-examples/artifacts/Configure-EdgePolicy/Configure-EdgePolicy.ps1`
- The `Invoke-WebRequest` call to the Edge Updates API and subsequent download via `Get-InternetFile` are now wrapped in `try { } catch { }`.
- On failure, logs a `Warning` and continues with `$EdgeTemplatesCab = $null`.
- The existing `$Script:AdmxImported` branch is unchanged: if ADMX is available (bundled CAB, pre-existing in PolicyDefinitions, or successfully downloaded), policy is applied via Registry.pol; otherwise, settings are written directly to the registry.

### `customer-examples/artifacts/Configure-Office365Policy/Configure-Office365.ps1`
- The `Get-InternetUrl` + `Get-InternetFile` download block is now wrapped in `try { } catch { }`.
- On failure, logs a `Warning` and continues with `$O365TemplatesExe = $null`.
- The existing `$Script:AdmxImported` branch is unchanged: Registry.pol when ADMX is available, direct registry writes as the fallback.

## Behavior

| Scenario | Before | After |
|---|---|---|
| Bundled CAB/EXE present | Use it (unchanged) | Use it (unchanged) |
| ADMX already in PolicyDefinitions | Skip download (unchanged) | Skip download (unchanged) |
| No ADMX, download succeeds | Use downloaded templates | Use downloaded templates |
| No ADMX, download fails | Script terminates with error | Logs warning, falls back to direct registry writes |