### PR TITLE
Add AVD multimedia redirection artifact

### DIFF
--- a/customer-examples/artifacts/Microsoft-AVD-Multimedia-Redirection/Install-MicrosoftAVDMultimediaRedirection.ps1
+++ b/customer-examples/artifacts/Microsoft-AVD-Multimedia-Redirection/Install-MicrosoftAVDMultimediaRedirection.ps1
@@ -1,0 +1,178 @@
+[CmdletBinding()]
+param (
+    [Parameter()]
+    [bool]$InstallEdgeExtension = $true,
+
+    [Parameter()]
+    [bool]$InstallChromeExtension = $true,
+
+    [Parameter()]
+    [int[]]$SuccessExitCodes = @(0, 3010)
+)
+
+$SoftwareName = 'Microsoft Multimedia Redirection Service'
+$Script:Name = 'Install-MicrosoftAVDMultimediaRedirection'
+$DownloadUrl = 'https://aka.ms/avdmmr/msi'
+$InstallerFileName = 'MsMMRHostInstaller_x64.msi'
+$EdgeExtension = 'joeclbldhdmoijbaagobkhlpfjglcihd;https://edge.microsoft.com/extensionwebstorebase/v1/crx'
+$ChromeExtension = 'lfmemoeeciijgkjkgbgikoonlkabmlno;https://clients2.google.com/service/update2/crx'
+
+function Write-Log {
+    param (
+        [Parameter(Mandatory = $false, Position = 0)]
+        [ValidateSet('Info', 'Warning', 'Error')]
+        [string]$Category = 'Info',
+
+        [Parameter(Mandatory = $true, Position = 1)]
+        [string]$Message
+    )
+
+    $content = "[$(Get-Date -Format 'MM/dd/yyyy HH:mm:ss')]`t$Category`t`t$Message"
+    if (-not $env:SUPPRESS_FILELOG) {
+        Add-Content -LiteralPath $Script:Log -Value $content -ErrorAction SilentlyContinue
+    }
+
+    switch ($Category) {
+        'Info' { Write-Host $content }
+        'Warning' { Write-Warning $content }
+        'Error' { Write-Error $content -ErrorAction Continue }
+    }
+}
+
+function New-Log {
+    param (
+        [Parameter(Mandatory = $true, Position = 0)]
+        [string]$Path
+    )
+
+    if ($env:SUPPRESS_FILELOG -eq '1') {
+        return
+    }
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        $null = New-Item -Path $Path -ItemType Directory
+    }
+
+    $date = Get-Date -UFormat '%Y-%m-%d %H-%M-%S'
+    $Script:Log = Join-Path $Path "$Script:Name-$date.log"
+    Add-Content -LiteralPath $Script:Log -Value "Date`t`t`tCategory`t`tDetails"
+}
+
+function Wait-MsiexecIdle {
+    param (
+        [int]$WaitSeconds = 300
+    )
+
+    $elapsed = 0
+    while ($elapsed -lt $WaitSeconds) {
+        $activeInstallers = Get-Process -Name 'msiexec' -ErrorAction SilentlyContinue |
+            Where-Object { -not $_.HasExited }
+        if (-not $activeInstallers) {
+            return
+        }
+
+        Write-Log -Message "msiexec is active. Waiting 10 seconds ($elapsed of $WaitSeconds seconds elapsed)."
+        Start-Sleep -Seconds 10
+        $elapsed += 10
+    }
+
+    throw "msiexec remained active after $WaitSeconds seconds."
+}
+
+function Assert-MicrosoftSignature {
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    $signature = Get-AuthenticodeSignature -LiteralPath $Path
+    if ($signature.Status -ne 'Valid' -or $signature.SignerCertificate.Subject -notmatch 'O=Microsoft Corporation') {
+        throw "The installer at '$Path' does not have a valid Microsoft signature."
+    }
+}
+
+function Add-ExtensionInstallPolicy {
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Extension
+    )
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        $null = New-Item -Path $Path -Force
+    }
+
+    $properties = Get-ItemProperty -LiteralPath $Path
+    $existingNames = @($properties.PSObject.Properties.Name | Where-Object { $_ -match '^\d+$' })
+    foreach ($name in $existingNames) {
+        if ($properties.$name -eq $Extension) {
+            Write-Log -Message "Browser extension policy '$Extension' is already configured at '$Path'."
+            return
+        }
+    }
+
+    $nextName = if ($existingNames.Count -eq 0) {
+        1
+    }
+    else {
+        [int](($existingNames | ForEach-Object { [int]$_ } | Measure-Object -Maximum).Maximum) + 1
+    }
+
+    $null = New-ItemProperty -LiteralPath $Path -Name $nextName -PropertyType String -Value $Extension -Force
+    Write-Log -Message "Configured browser extension policy '$Extension' at '$Path'."
+}
+
+$ErrorActionPreference = 'Stop'
+New-Log -Path (Join-Path $env:SystemRoot 'Logs')
+Write-Log -Message "Starting '$PSCommandPath'."
+
+$installerPath = Join-Path $PSScriptRoot $InstallerFileName
+if (Test-Path -LiteralPath $installerPath -PathType Leaf) {
+    Write-Log -Message "Using pre-staged installer '$installerPath'."
+}
+else {
+    $installerPath = Join-Path $env:TEMP $InstallerFileName
+    Write-Log -Message "Downloading '$SoftwareName' from '$DownloadUrl'."
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    Invoke-WebRequest -Uri $DownloadUrl -OutFile $installerPath -UseBasicParsing
+}
+
+Assert-MicrosoftSignature -Path $installerPath
+
+$runningBrowsers = @(Get-Process -Name 'msedge', 'chrome' -ErrorAction SilentlyContinue)
+if ($runningBrowsers.Count -gt 0) {
+    throw 'Microsoft Edge and Google Chrome must be closed before installing multimedia redirection.'
+}
+
+$msiLogPath = Join-Path $env:SystemRoot "Logs\$Script:Name-msiexec.log"
+$arguments = "/i `"$installerPath`" /quiet /norestart /L*v `"$msiLogPath`""
+Write-Log -Message "Installing '$SoftwareName'."
+Wait-MsiexecIdle
+$installer = Start-Process -FilePath 'msiexec.exe' -ArgumentList $arguments -PassThru
+if (-not $installer.WaitForExit(600000)) {
+    $installer.Kill()
+    throw "'$SoftwareName' installation timed out after 10 minutes."
+}
+
+if ($installer.ExitCode -notin $SuccessExitCodes) {
+    throw "'$SoftwareName' installation failed with exit code $($installer.ExitCode). Review '$msiLogPath'."
+}
+
+if ($InstallEdgeExtension) {
+    Add-ExtensionInstallPolicy -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Edge\ExtensionInstallForcelist' -Extension $EdgeExtension
+}
+
+if ($InstallChromeExtension) {
+    Add-ExtensionInstallPolicy -Path 'HKLM:\SOFTWARE\Policies\Google\Chrome\ExtensionInstallForcelist' -Extension $ChromeExtension
+}
+
+if ($installer.ExitCode -eq 3010) {
+    Write-Log -Message "'$SoftwareName' installed successfully. A restart is required."
+}
+else {
+    Write-Log -Message "'$SoftwareName' installed successfully."
+}
+
+Write-Log -Message "Completed '$SoftwareName' installation."

--- a/customer-examples/artifacts/Microsoft-AVD-Multimedia-Redirection/README.md
+++ b/customer-examples/artifacts/Microsoft-AVD-Multimedia-Redirection/README.md
@@ -1,0 +1,111 @@
+# Microsoft-AVD-Multimedia-Redirection
+
+> **Azure Commercial only:** Microsoft doesn't support Azure Virtual Desktop multimedia
+> redirection in Azure US Government. Do not use this artifact for Government, GCC, GCC High,
+> or DoD deployments.
+>
+> **Before you start:** Copy this folder to
+> `customer/artifacts/Microsoft-AVD-Multimedia-Redirection/`. Add the
+> `AVDMultimediaRedirection` entry from
+> [`customer-examples/parameters/imageManagement/downloads.json`](../../../customer-examples/parameters/imageManagement/downloads.json)
+> to `customer/parameters/imageManagement/downloads.json`, then run
+> `Update-ImageArtifacts.ps1`.
+
+Installs the latest Microsoft Remote Desktop Multimedia Redirection Service and browser
+extension components on Azure Virtual Desktop session hosts. By default, the script also
+configures the Microsoft Edge and Google Chrome extension force-install policies so users don't
+need to enable the extension manually.
+
+## Prerequisites
+
+- Azure Virtual Desktop in Azure Commercial.
+- The latest Microsoft Edge or Google Chrome on the session host.
+- Microsoft Visual C++ Redistributable 2015-2022 version 14.32.31332.0 or later on the session
+  host and each local Windows endpoint. The
+  [Microsoft-VCRedistributable](../Microsoft-VCRedistributable/) example installs the session-host
+  x64 runtime.
+- Windows App on Windows 2.0.297.0 or later, or Remote Desktop client 1.2.5709 or later.
+- Access from the session host to the applicable browser extension store when centrally enabling
+  the extension. The extension updates separately from the host service.
+
+See [Multimedia redirection for video playback and calls](https://learn.microsoft.com/azure/virtual-desktop/multimedia-redirection-video-playback-calls)
+for the current client versions, supported sites, and endpoint requirements.
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `InstallEdgeExtension` | `bool` | `$true` | Force-install and enable the Microsoft Edge extension. |
+| `InstallChromeExtension` | `bool` | `$true` | Force-install and enable the Google Chrome extension. |
+| `SuccessExitCodes` | `int[]` | `0, 3010` | MSI exit codes treated as success. |
+
+Disable a browser policy when that browser isn't deployed or its extensions are managed by a
+different enterprise policy. For example:
+
+```powershell
+./Install-MicrosoftAVDMultimediaRedirection.ps1 -InstallChromeExtension $false
+```
+
+## Folder contents
+
+```plaintext
+Microsoft-AVD-Multimedia-Redirection/
+    Install-MicrosoftAVDMultimediaRedirection.ps1
+    MsMMRHostInstaller_x64.msi
+```
+
+The MSI is optional for connected image builds because the script downloads it if it isn't
+present. Pre-stage the MSI when the image build VM can't reach the Microsoft download endpoint.
+
+## Stage the installer
+
+Add this entry to `customer/parameters/imageManagement/downloads.json`:
+
+```json
+"AVDMultimediaRedirection": {
+    "Description": "Microsoft AVD Multimedia Redirection Service x64 MSI. Azure Commercial only.",
+    "DownloadUrl": "https://aka.ms/avdmmr/msi",
+    "DestinationFileName": "MsMMRHostInstaller_x64.msi",
+    "DestinationFolders": [
+        "Microsoft-AVD-Multimedia-Redirection"
+    ]
+}
+```
+
+Run the artifact update from the repository root:
+
+```powershell
+./deployments/Update-ImageArtifacts.ps1 `
+    -StorageAccountResourceId '<artifactsStorageAccountResourceId>'
+```
+
+For a disconnected management environment, download the payload on an internet-connected
+machine and transfer the artifact folder through your approved process:
+
+```powershell
+Invoke-WebRequest 'https://aka.ms/avdmmr/msi' `
+    -OutFile 'MsMMRHostInstaller_x64.msi'
+```
+
+The install script verifies that the MSI has a valid Microsoft signature before running it.
+
+## What the script does
+
+1. Uses `MsMMRHostInstaller_x64.msi` from the artifact folder, or downloads the current MSI.
+2. Verifies the MSI Authenticode signature is valid and issued to Microsoft Corporation.
+3. Confirms Microsoft Edge and Google Chrome aren't running.
+4. Installs the MSI silently with `msiexec /quiet /norestart`.
+5. Optionally adds the official MMR extension to the Edge and Chrome force-install policies.
+
+The MSI installs both the host service and browser extension components. The script preserves
+existing force-installed extensions and adds MMR only when it isn't already listed.
+
+## Logs and updates
+
+Script logs are written to
+`C:\Windows\Logs\Install-MicrosoftAVDMultimediaRedirection-<timestamp>.log`. Detailed MSI output
+is written to `C:\Windows\Logs\Install-MicrosoftAVDMultimediaRedirection-msiexec.log`.
+
+The service doesn't update automatically. Re-run `Update-ImageArtifacts.ps1` before each image
+build and rebuild the image to pick up the current release. Installing a newer MSI automatically
+replaces the previous version.

--- a/customer-examples/artifacts/README.md
+++ b/customer-examples/artifacts/README.md
@@ -74,6 +74,7 @@ configuration only) or require manually staged files (such as patch files for
 | [Git-for-Windows](Git-for-Windows/) | Git for Windows | `GitForWindows` |
 | [Google-Chrome-Enterprise](Google-Chrome-Enterprise/) | Google Chrome Enterprise MSI | `GoogleChromeEnterprise` |
 | [LGPO](LGPO/) | Microsoft LGPO tool (Local Group Policy Object) | `LGPO` |
+| [Microsoft-AVD-Multimedia-Redirection](Microsoft-AVD-Multimedia-Redirection/) | AVD multimedia redirection service and browser extensions (Azure Commercial only) | `AVDMultimediaRedirection` |
 | [Microsoft-AzCLI](Microsoft-AzCLI/) | Azure CLI | `AzCli` |
 | [Microsoft-Edge-Enterprise](Microsoft-Edge-Enterprise/) | Microsoft Edge Enterprise MSI | `MicrosoftEdgeEnterprise` |
 | [Microsoft-FSLogix](Microsoft-FSLogix/) | FSLogix Apps | `FSLogix` |

--- a/customer-examples/parameters/imageManagement/downloads.json
+++ b/customer-examples/parameters/imageManagement/downloads.json
@@ -255,6 +255,14 @@
             "BuiltIn-UWP-Apps\\AV1VideoExtension"
         ]
     },
+    "AVDMultimediaRedirection": {
+        "Description": "Microsoft AVD Multimedia Redirection Service x64 MSI. Azure Commercial only. The install script also downloads this at image build time if not pre-staged.",
+        "DownloadUrl": "https://aka.ms/avdmmr/msi",
+        "DestinationFileName": "MsMMRHostInstaller_x64.msi",
+        "DestinationFolders": [
+            "Microsoft-AVD-Multimedia-Redirection"
+        ]
+    },
     "VCRedistributableX64": {
         "Description": "Microsoft Visual C++ Redistributable (latest) x64 installer. Install-MicrosoftVCRedistributable.ps1 also downloads this at image build time if not pre-staged (connected builds only).",
         "DownloadUrl": "https://aka.ms/vs/17/release/vc_redist.x64.exe",


### PR DESCRIPTION
## Summary

- add an Azure Commercial customer example for installing the AVD Multimedia Redirection service
- support pre-staged or connected MSI acquisition with Microsoft signature validation and MSI logging
- centrally enable the official Edge and Chrome extensions while preserving existing force-install entries
- add the package to the example download manifest and artifact catalog
- document client, browser, and Visual C++ prerequisites and the Azure Government support limitation

## Validation

- `Test-ArtifactPackage.ps1`
- PowerShell parser and ASCII checks
- `downloads.json` parsing
- Markdown diagnostics
- `git diff --check`

## Support boundary

Microsoft does not support AVD multimedia redirection in Azure US Government, GCC, GCC High, or DoD. The example is explicitly labeled Azure Commercial only.